### PR TITLE
402 profile

### DIFF
--- a/canopen/__init__.py
+++ b/canopen/__init__.py
@@ -1,5 +1,6 @@
 from .version import __version__
-from .network import Network
+from .network import Network, NodeScanner
 from .node import Node
 from .sdo import SdoCommunicationError, SdoAbortedError
 from .objectdictionary import import_od, ObjectDictionary, ObjectDictionaryError
+from .profiles.p402 import Node402

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -55,15 +55,15 @@ class Node402(Node):
         # first read the current PDO setup and only change TPDO1
         print(self.nmt.state)
         self.nmt.state = 'PRE-OPERATIONAL'
-        self.pdo.read()
+        self.pdo.tx[1].read()
         self.pdo.tx[1].clear()
         # Use register as to stay manufacturer agnostic
         self.pdo.tx[1].add_variable(0x6041)
         # add callback to listen to TPDO1 and change 402 state
         self.pdo.tx[1].add_callback(self.powerstate_402.on_PDO1_callback)
-        self.pdo.trans_type = 255
+        self.pdo.tx[1].trans_type = 255
         self.pdo.tx[1].enabled = True
-        self.pdo.save()
+        self.pdo.tx[1].save()
         self.nmt.state = 'OPERATIONAL'
 
 class PowerStateEngine(object):

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -46,12 +46,12 @@ class Node402(Node):
 
     def __init__(self, node_id, object_dictionary):
         super(Node402, self).__init__(node_id, object_dictionary)
-        self.powerstate_402 = PowerStateEngine(self)
+        self.powerstate_402 = PowerStateMachine(self)
         self.powerstate_402.network = self.network
 
-    def setup_402_state_engine(self):
+    def setup_402_state_machine(self):
         # setup TPDO1 for this node
-        # TPDO1 will transmit the statusword of the 402 power state engine
+        # TPDO1 will transmit the statusword of the 402 control state machine
         # first read the current PDO setup and only change TPDO1
         print(self.nmt.state)
         self.nmt.state = 'PRE-OPERATIONAL'
@@ -66,9 +66,9 @@ class Node402(Node):
         self.pdo.tx[1].save()
         self.nmt.state = 'OPERATIONAL'
 
-class PowerStateEngine(object):
-    """A CANopen CiA 402 Power State engine. Listens to state changes
-    of the DS402 Power State engine by means of TPDO 1 Statusword.
+class PowerStateMachine(object):
+    """A CANopen CiA 402 Power State machine. Listens to state changes
+    of the DS402 Power State machine by means of TPDO 1 Statusword.
 
     - Controlword 0x6040 causes transitions
     - Statusword 0x6041 gives the current state
@@ -84,8 +84,8 @@ class PowerStateEngine(object):
     def on_PDO1_callback(mapobject):
         # this function receives a map object.
         # this map object is then used for changing the
-        # Node402.PowerstateEngine._state by reading the statusword
-        # The TPDO1 is defined in setup_402_state_engine
+        # Node402.PowerstateMachine._state by reading the statusword
+        # The TPDO1 is defined in setup_402_state_machine
         statusword = mapobject[0].raw
         for key, value in POWER_STATES_402.iteritems():
     		# check if the value after applying the bitmask (value[0])

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -1,0 +1,144 @@
+# inspired by the NmtMaster code
+
+from canopen import Node, NodeScanner
+
+# status word 0x6041 bitmask and values in the list in the dictionary value
+POWER_STATES_402 = {
+    'NOT READY TO SWITCH ON': [0x4F, 0x00],
+    'SWITCH ON DISABLED'    : [0x4F, 0x40],
+    'READY TO SWITCH ON'    : [0x6F, 0x21],
+    'SWITCHED ON'           : [0x6F, 0x23],
+    'OPERATION ENABLED'     : [0x6F, 0x27],
+    'FAULT'                 : [0x4F, 0x08],
+    'FAULT REACTION ACTIVE' : [0x4F, 0x0F],
+    'QUICK STOP ACTIVE'     : [0x6F, 0x07]
+}
+
+# control word 0x6040
+POWER_STATE_COMMANDS = {
+    'SWITCH ON DISABLED'    : 0x80,
+    'DISABLE VOLTAGE'       : 0x04,
+    'READY TO SWITCH ON'    : 0x06,
+    'SWITCHED ON'           : 0x07,
+    'OPERATION ENABLED'     : 0x0F,
+    'QUICK STOP ACTIVE'     : 0x02
+}
+
+COMMAND_TO_POWER_STATE = {
+    0x80: 'SWITCH ON DISABLED',
+    0x02: 'SWITCH ON DISABLED',
+    0x06: 'READY TO SWITCH ON',
+    0x07: 'SWITCHED ON',
+    0x0F: 'OPERATION ENABLED',
+    0x02: 'QUICK STOP ACTIVE'
+}
+
+class Node402(Node):
+    """A CANopen CiA 402 profile slave node.
+
+    :param int node_id:
+        Node ID (set to None or 0 if specified by object dictionary)
+    :param object_dictionary:
+        Object dictionary as either a path to a file, an ``ObjectDictionary``
+        or a file like object.
+    :type object_dictionary: :class:`str`, :class:`canopen.ObjectDictionary`
+    """
+
+    def __init__(self, node_id, object_dictionary):
+        super(Node402, self).__init__(node_id, object_dictionary)
+        self.powerstate_402 = PowerStateEngine(self)
+        self.powerstate_402.network = self.network
+
+    def setup_402_state_engine(self):
+        # setup TPDO1 for this node
+        # TPDO1 will transmit the statusword of the 402 power state engine
+        # first read the current PDO setup and only change TPDO1
+        print(self.nmt.state)
+        self.nmt.state = 'PRE-OPERATIONAL'
+        self.pdo.read()
+        self.pdo.tx[1].clear()
+        # Use register as to stay manufacturer agnostic
+        self.pdo.tx[1].add_variable(0x6041)
+        # add callback to listen to TPDO1 and change 402 state
+        self.pdo.tx[1].add_callback(self.powerstate_402.on_PDO1_callback)
+        self.pdo.trans_type = 255
+        self.pdo.tx[1].enabled = True
+        self.pdo.save()
+        self.nmt.state = 'OPERATIONAL'
+
+class PowerStateEngine(object):
+    """A CANopen CiA 402 Power State engine. Listens to state changes
+    of the DS402 Power State engine by means of TPDO 1 Statusword.
+
+    - Controlword 0x6040 causes transitions
+    - Statusword 0x6041 gives the current state
+
+    """
+
+    def __init__(self, node):
+        self.id = node.id
+        self.node = node
+        self._state = 'NOT READY TO SWITCH ON'
+
+    @staticmethod
+    def on_PDO1_callback(mapobject):
+        # this function receives a map object.
+        # this map object is then used for changing the
+        # Node402.PowerstateEngine._state
+        #
+        # I would have preferred to retrieve the statusword by means of the
+        # register as to make this ParameterName string (vendor) agnostic like:
+        # statusword = mapobject.pdo_node.tx[1][0x6041].raw
+        #
+        # Since I haven't found a way to do this the ParameterName is first
+        # retrieved from the OD, and used for extracting the data in the Map.
+        description = mapobject.pdo_node.node.object_dictionary[0x6041].name
+        statusword = mapobject.pdo_node.tx[1][description].raw
+        for key, value in POWER_STATES_402.iteritems():
+    		# check if the value after applying the bitmask (value[0])
+    		# corresponds with the corresponding value to determine
+    		# the current status
+            bitmaskvalue = statusword & value[0]
+            if bitmaskvalue == value[1]:
+                mapobject.pdo_node.node.powerstate_402._state = key
+
+    @property
+    def state(self):
+        """Attribute to get or set node's state as a string.
+
+        States of the node can be one of:
+
+        - 'NOT READY TO SWITCH ON'
+        - 'SWITCH ON DISABLED'
+        - 'READY TO SWITCH ON'
+        - 'SWITCHED ON'
+        - 'OPERATION ENABLED'
+        - 'FAULT'
+        - 'FAULT REACTION ACTIVE'
+        - 'QUICK STOP ACTIVE'
+
+        States to switch to can be one of:
+
+        - 'SWITCH ON DISABLED'
+        - 'DISABLE VOLTAGE'
+        - 'READY TO SWITCH ON'
+        - 'SWITCHED ON'
+        - 'OPERATION ENABLED'
+        - 'QUICK STOP ACTIVE'
+
+        """
+        if self._state in POWER_STATES_402.values():
+            return POWER_STATES_402[self._state]
+        else:
+            return self._state
+
+    @state.setter
+    def state(self, new_state):
+        if new_state in POWER_STATE_COMMANDS:
+            code = POWER_STATE_COMMANDS[new_state]
+        else:
+            raise ValueError("'%s' is an invalid state. Must be one of %s." %
+                             (new_state, ", ".join(POWER_STATE_COMMANDS)))
+        # send the control word in a manufacturer agnostic way
+        # by not using the EDS ParameterName but the register number
+        self.node.sdo[0x6040].raw = code

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -84,20 +84,12 @@ class PowerStateEngine(object):
     def on_PDO1_callback(mapobject):
         # this function receives a map object.
         # this map object is then used for changing the
-        # Node402.PowerstateEngine._state
-        #
-        # I would have preferred to retrieve the statusword by means of the
-        # register as to make this ParameterName string (vendor) agnostic like:
-        # statusword = mapobject.pdo_node.tx[1][0x6041].raw
-        #
-        # Since I haven't found a way to do this the ParameterName is first
-        # retrieved from the OD, and used for extracting the data in the Map.
-        description = mapobject.pdo_node.node.object_dictionary[0x6041].name
-        statusword = mapobject.pdo_node.tx[1][description].raw
+        # Node402.PowerstateEngine._state by reading the statusword
+        # The TPDO1 is defined in setup_402_state_engine
+        statusword = mapobject[0].raw
         for key, value in POWER_STATES_402.iteritems():
     		# check if the value after applying the bitmask (value[0])
-    		# corresponds with the corresponding value to determine
-    		# the current status
+    		# corresponds with the value[1] to determine the current status
             bitmaskvalue = statusword & value[0]
             if bitmaskvalue == value[1]:
                 mapobject.pdo_node.node.powerstate_402._state = key

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,6 +36,7 @@ Easiest way to install is to use pip_::
    sync
    emcy
    integration
+   profiles
 
 
 .. _CANopen: https://en.wikipedia.org/wiki/CANopen

--- a/doc/profiles.rst
+++ b/doc/profiles.rst
@@ -1,0 +1,87 @@
+Device profiles
+================
+
+On top of the standard CANopen functionality which includes the DS301
+application layer there can be additional profiles specifically for certain
+applications.
+
+CiA 402 CANopen device profile for motion controllers and drives
+----------------------------------------------------------------
+
+This device profile has a control state machine for controlling the behaviour
+of the drive. Therefore one needs to instantiate a node with the
+:class:`Node402` class
+
+Create a node with Node402::
+
+    import canopen
+    from canopen.profiles.p402 import Node402
+
+    some_node = canopen.Node402(3, 'someprofile.eds')
+    network = canopen.Network()
+    network.add_node(some_node)
+
+The Power State Machine
+````````````````````````
+
+The :class:`PowerStateMachine` class provides the means of controlling the
+states of this state machine. The static method `on_PDO1_callback()` is added
+to the TPDO1 callback.
+
+State changes can be controlled by writing a specific value to register
+0x6040, which is called the "Controlword".
+The current status can be read from the device by reading the register
+0x6041, which is called the "Statusword".
+Changes in state can only be done in the 'OPERATIONAL' state of the NmtMaster
+
+TPDO1 needs to be set up correctly. For this, run the the
+`Node402.setup_402_state_machine()` method. Note that this setup
+routine will change only TPDO1 and automatically go to the 'OPERATIONAL' state
+of the NmtMaster::
+
+    # run the setup routine for TPDO1 and it's callback
+    some_node.setup_402_state_machine()
+
+Write Controlword and read Statusword::
+
+    # command to go to 'READY TO SWITCH ON' from 'NOT READY TO SWITCH ON' or 'SWITCHED ON'
+    some_node.sdo[0x6040].raw = 0x06
+
+    # Read the state of the Statusword
+    some_node.sdo[0x6041].raw
+
+During operation the state can change to states which cannot be commanded
+by the Controlword, for example a 'FAULT' state.
+Therefore the :class:`PowerStateMachine` class (in similarity to the :class:`NmtMaster`
+class) automatically monitors state changes of the Statusword which is sent
+by TPDO1. The available callback on thet TPDO1 will then extract the
+information and mirror the state change in the :attr:`Node402.powerstate_402`
+attribute.
+
+Similar to the :class:`NmtMaster` class, the states of the :class:`Node402`
+class :attr:`._state` attribute can be read and set (command) by a string::
+
+    # command a state (an SDO message will be called)
+    some_node.powerstate_402.state = 'SWITCHED ON'
+    # read the current state
+    some_node.powerstate_402.state = 'SWITCHED ON'
+
+Available states:
+
+- 'NOT READY TO SWITCH ON'
+- 'SWITCH ON DISABLED'
+- 'READY TO SWITCH ON'
+- 'SWITCHED ON'
+- 'OPERATION ENABLED'
+- 'FAULT'
+- 'FAULT REACTION ACTIVE'
+- 'QUICK STOP ACTIVE'
+
+Available commands
+
+- 'SWITCH ON DISABLED'
+- 'DISABLE VOLTAGE'
+- 'READY TO SWITCH ON'
+- 'SWITCHED ON'
+- 'OPERATION ENABLED'
+- 'QUICK STOP ACTIVE'


### PR DESCRIPTION
for issue #16 I've added code to use nodes with a CiA 402 device profile.

- the `Node402` class is a subclass of `Node`.
- added to this is a `PowerStateEngine` class for monitoring state changes. Inspired by the NMT state  monitoring in the `NmtMaster`
- states are changed by adding the `on_PDO1_callback function` to the TPDO1 callback