### PR TITLE
SDO block transfer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,6 @@ Pull requests are most welcome!
 
 * More unit test coverage
 * Period transmits using python-can cyclic API
-* SDO block transfer
 * XDD support
 
 

--- a/canopen/sdo.py
+++ b/canopen/sdo.py
@@ -579,6 +579,8 @@ class BlockDownloadStream(io.RawIOBase):
                 "on the same SDO channel?").format(res_index, res_subindex))
         self._blksize, = struct.unpack_from("B", response, 4)
         logger.debug("Server requested a block size of %d", self._blksize)
+        if res_command & CRC_SUPPORTED:
+            logger.debug("The server supports CRC verification")
 
     def write(self, b):
         """
@@ -656,6 +658,8 @@ class BlockDownloadStream(io.RawIOBase):
 
     def close(self):
         """Closes the stream."""
+        if self.closed:
+            return
         super(BlockDownloadStream, self).close()
         if not self._done:
             # Send an empty sequence with end flag
@@ -671,8 +675,8 @@ class BlockDownloadStream(io.RawIOBase):
         response = self.sdo_client.request_response(request)
         res_command, = struct.unpack_from("B", response)
         if not res_command & END_BLOCK_DOWNLOAD:
-            raise SdoCommunicationError("SDO block download unsuccessful")
-        logger.info("Block transfer successful")
+            raise SdoCommunicationError("Block download unsuccessful")
+        logger.info("Block download successful")
 
     def writable(self):
         return True

--- a/canopen/sdo.py
+++ b/canopen/sdo.py
@@ -576,7 +576,7 @@ class BlockDownloadStream(io.RawIOBase):
                 "Node returned a value for 0x{:X}:{:d} instead, "
                 "maybe there is another SDO client communicating "
                 "on the same SDO channel?").format(res_index, res_subindex))
-        self._blksize = struct.unpack_from("B", response, 4)
+        self._blksize, = struct.unpack_from("B", response, 4)
 
     def write(self, b):
         """

--- a/doc/sdo.rst
+++ b/doc/sdo.rst
@@ -16,9 +16,6 @@ and SDO Block download/upload. The SDO block transfer is a newer addition to
 standard, which allows large amounts of data to be transferred with slightly
 less protocol overhead.
 
-.. note::
-    SDO block transfers are not yet supported.
-
 The COB-IDs of the respective SDO transfer messages from client to server and
 server to client can be set in the object dictionary. Up to 128 SDO servers can
 be set up in the object dictionary at addresses 0x1200 - 0x127F. Similarly, the
@@ -83,6 +80,28 @@ when dealing with large amounts of data::
     # Clean-up
     infile.close()
     outfile.close()
+
+Most APIs accepting file objects should also be able to accept this.
+
+Block transfer can be used to effectively transfer large amounts of data if the
+server supports it. This is done through the file object interface::
+
+    FIRMWARE_PATH = '/path/to/firmware.bin'
+    FILESIZE = os.path.getsize(FIRMWARE_PATH)
+    infile = open(FIRMWARE_PATH, 'rb')
+    outfile = node.sdo['Firmware'].open('wb', size=FILESIZE, block_transfer=True)
+
+    # Iteratively transfer data without having to read all into memory
+    while True:
+        data = infile.read(1024)
+        if not data:
+            break
+        outfile.write(data)
+    infile.close()
+    outfile.close()
+
+.. warning::
+   Block transfer is still in experimental stage!
 
 
 API
@@ -199,6 +218,14 @@ API
     :members: read, readinto, readall, readline, readlines
 
 .. autoclass:: canopen.sdo.WritableStream
+    :show-inheritance:
+    :members: write, close
+
+.. autoclass:: canopen.sdo.BlockUploadStream
+    :show-inheritance:
+    :members: read, readinto, readall, readline, readlines
+
+.. autoclass:: canopen.sdo.BlockDownloadStream
     :show-inheritance:
     :members: write, close
 

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -1,9 +1,13 @@
 import os
 import unittest
+import binascii
 import canopen
 
 
 EDS_PATH = os.path.join(os.path.dirname(__file__), 'sample.eds')
+
+TX = 1
+RX = 2
 
 
 class TestSDO(unittest.TestCase):
@@ -18,10 +22,14 @@ class TestSDO(unittest.TestCase):
         Checks that the message data is according to expected and answers
         with the provided data.
         """
-        #print("%r" % data)
-        self.assertSequenceEqual(data, self.data.pop(0))
+        next_data = self.data.pop(0)
+        self.assertEqual(next_data[0], TX, "No transmission was expected")
+        #print("> %s (%s)" % (binascii.hexlify(data), binascii.hexlify(next_data[1])))
+        self.assertSequenceEqual(data, next_data[1])
         self.assertEqual(can_id, 0x602)
-        self.network.notify(0x582, self.data.pop(0), 0.0)
+        while self.data and self.data[0][0] == RX:
+            #print("< %s" % binascii.hexlify(self.data[0][1]))
+            self.network.notify(0x582, self.data.pop(0)[1], 0.0)
 
     def setUp(self):
         network = canopen.Network()
@@ -32,64 +40,83 @@ class TestSDO(unittest.TestCase):
 
     def test_expedited_upload(self):
         self.data = [
-            b'\x40\x18\x10\x01\x00\x00\x00\x00',
-            b'\x43\x18\x10\x01\x04\x00\x00\x00'
+            (TX, b'\x40\x18\x10\x01\x00\x00\x00\x00'),
+            (RX, b'\x43\x18\x10\x01\x04\x00\x00\x00')
         ]
         vendor_id = self.network[2].sdo[0x1018][1].raw
         self.assertEqual(vendor_id, 4)
 
         # UNSIGNED8 without padded data part (see issue #5)
         self.data = [
-            b'\x40\x00\x14\x02\x00\x00\x00\x00',
-            b'\x4f\x00\x14\x02\xfe'
+            (TX, b'\x40\x00\x14\x02\x00\x00\x00\x00'),
+            (RX, b'\x4f\x00\x14\x02\xfe')
         ]
         trans_type = self.network[2].sdo[0x1400]['Transmission type RPDO 1'].raw
         self.assertEqual(trans_type, 254)
 
     def test_expedited_download(self):
         self.data = [
-            b'\x2b\x17\x10\x00\xa0\x0f\x00\x00',
-            b'\x60\x17\x10\x00\x00\x00\x00\x00'
+            (TX, b'\x2b\x17\x10\x00\xa0\x0f\x00\x00'),
+            (RX, b'\x60\x17\x10\x00\x00\x00\x00\x00')
         ]
         self.network[2].sdo[0x1017].raw = 4000
 
     def test_segmented_upload(self):
         self.data = [
-            b'\x40\x08\x10\x00\x00\x00\x00\x00',
-            b'\x41\x08\x10\x00\x1A\x00\x00\x00',
-            b'\x60\x00\x00\x00\x00\x00\x00\x00',
-            b'\x00\x54\x69\x6E\x79\x20\x4E\x6F',
-            b'\x70\x00\x00\x00\x00\x00\x00\x00',
-            b'\x10\x64\x65\x20\x2D\x20\x4D\x65',
-            b'\x60\x00\x00\x00\x00\x00\x00\x00',
-            b'\x00\x67\x61\x20\x44\x6F\x6D\x61',
-            b'\x70\x00\x00\x00\x00\x00\x00\x00',
-            b'\x15\x69\x6E\x73\x20\x21\x00\x00'
+            (TX, b'\x40\x08\x10\x00\x00\x00\x00\x00'),
+            (RX, b'\x41\x08\x10\x00\x1A\x00\x00\x00'),
+            (TX, b'\x60\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x00\x54\x69\x6E\x79\x20\x4E\x6F'),
+            (TX, b'\x70\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x10\x64\x65\x20\x2D\x20\x4D\x65'),
+            (TX, b'\x60\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x00\x67\x61\x20\x44\x6F\x6D\x61'),
+            (TX, b'\x70\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x15\x69\x6E\x73\x20\x21\x00\x00')
         ]
         device_name = self.network[2].sdo[0x1008].raw
         self.assertEqual(device_name, "Tiny Node - Mega Domains !")
 
     def test_segmented_download(self):
         self.data = [
-            b'\x21\x00\x20\x00\x0d\x00\x00\x00',
-            b'\x60\x00\x20\x00\x00\x00\x00\x00',
-            b'\x00\x41\x20\x6c\x6f\x6e\x67\x20',
-            b'\x20\x00\x20\x00\x00\x00\x00\x00',
-            b'\x13\x73\x74\x72\x69\x6e\x67\x00',
-            b'\x30\x00\x20\x00\x00\x00\x00\x00'
+            (TX, b'\x21\x00\x20\x00\x0d\x00\x00\x00'),
+            (RX, b'\x60\x00\x20\x00\x00\x00\x00\x00'),
+            (TX, b'\x00\x41\x20\x6c\x6f\x6e\x67\x20'),
+            (RX, b'\x20\x00\x20\x00\x00\x00\x00\x00'),
+            (TX, b'\x13\x73\x74\x72\x69\x6e\x67\x00'),
+            (RX, b'\x30\x00\x20\x00\x00\x00\x00\x00')
         ]
         self.network[2].sdo['Writable string'].raw = 'A long string'
 
+    def test_block_download(self):
+        self.data = [
+            (TX, b'\xc6\x00\x20\x00\x1e\x00\x00\x00'),
+            (RX, b'\xa4\x00\x20\x00\x7f\x00\x00\x00'),
+            (TX, b'\x01\x41\x20\x72\x65\x61\x6c\x6c'),
+            (TX, b'\x02\x79\x20\x72\x65\x61\x6c\x6c'),
+            (TX, b'\x03\x79\x20\x6c\x6f\x6e\x67\x20'),
+            (TX, b'\x04\x73\x74\x72\x69\x6e\x67\x2e'),
+            (TX, b'\x85\x2e\x2e\x00\x00\x00\x00\x00'),
+            (RX, b'\xa2\x05\x7f\x00\x00\x00\x00\x00'),
+            (TX, b'\xd5\x45\x69\x00\x00\x00\x00\x00'),
+            (RX, b'\xa1\x00\x00\x00\x00\x00\x00\x00')
+        ]
+        data = b'A really really long string...'
+        fp = self.network[2].sdo['Writable string'].open(
+            'wb', size=len(data), block_transfer=True)
+        fp.write(data)
+        fp.close()
+
     def test_writable_file(self):
         self.data = [
-            b'\x20\x00\x20\x00\x00\x00\x00\x00',
-            b'\x60\x00\x20\x00\x00\x00\x00\x00',
-            b'\x00\x31\x32\x33\x34\x35\x36\x37',
-            b'\x20\x00\x20\x00\x00\x00\x00\x00',
-            b'\x1a\x38\x39\x00\x00\x00\x00\x00',
-            b'\x30\x00\x20\x00\x00\x00\x00\x00',
-            b'\x0f\x00\x00\x00\x00\x00\x00\x00',
-            b'\x20\x00\x20\x00\x00\x00\x00\x00'
+            (TX, b'\x20\x00\x20\x00\x00\x00\x00\x00'),
+            (RX, b'\x60\x00\x20\x00\x00\x00\x00\x00'),
+            (TX, b'\x00\x31\x32\x33\x34\x35\x36\x37'),
+            (RX, b'\x20\x00\x20\x00\x00\x00\x00\x00'),
+            (TX, b'\x1a\x38\x39\x00\x00\x00\x00\x00'),
+            (RX, b'\x30\x00\x20\x00\x00\x00\x00\x00'),
+            (TX, b'\x0f\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x20\x00\x20\x00\x00\x00\x00\x00')
         ]
         fp = self.network[2].sdo['Writable string'].open('wb')
         fp.write(b'1234')
@@ -102,8 +129,8 @@ class TestSDO(unittest.TestCase):
 
     def test_abort(self):
         self.data = [
-            b'\x40\x18\x10\x01\x00\x00\x00\x00',
-            b'\x80\x18\x10\x01\x11\x00\x09\x06'
+            (TX, b'\x40\x18\x10\x01\x00\x00\x00\x00'),
+            (RX, b'\x80\x18\x10\x01\x11\x00\x09\x06')
         ]
         with self.assertRaises(canopen.SdoAbortedError) as cm:
             vendor_id = self.network[2].sdo[0x1018][1].raw

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -107,6 +107,24 @@ class TestSDO(unittest.TestCase):
         fp.write(data)
         fp.close()
 
+    def test_block_upload(self):
+        self.data = [
+            (TX, b'\xa4\x08\x10\x00\x7f\x00\x00\x00'),
+            (RX, b'\xc6\x08\x10\x00\x1a\x00\x00\x00'),
+            (TX, b'\xa3\x00\x00\x00\x00\x00\x00\x00'),
+            (RX, b'\x01\x54\x69\x6e\x79\x20\x4e\x6f'),
+            (RX, b'\x02\x64\x65\x20\x2d\x20\x4d\x65'),
+            (RX, b'\x03\x67\x61\x20\x44\x6f\x6d\x61'),
+            (RX, b'\x84\x69\x6e\x73\x20\x21\x00\x00'),
+            (TX, b'\xa2\x04\x7f\x00\x00\x00\x00\x00'),
+            (RX, b'\xc9\x40\xe1\x00\x00\x00\x00\x00'),
+            (TX, b'\xa1\x00\x00\x00\x00\x00\x00\x00')
+        ]
+        fp = self.network[2].sdo[0x1008].open('r', block_transfer=True)
+        data = fp.read()
+        fp.close()
+        self.assertEqual(data, 'Tiny Node - Mega Domains !')
+
     def test_writable_file(self):
         self.data = [
             (TX, b'\x20\x00\x20\x00\x00\x00\x00\x00'),


### PR DESCRIPTION
Addresses part of issue #14.

Intended usage:
```python
data = b'A really really long string...'
fp = node.sdo['Some Variable'].open('wb', size=len(data), block_transfer=True)
fp.write(data)
fp.close()
```