### PR TITLE
pre-PR for homing functionality + 402 state change callbacks

### DIFF
--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -240,7 +240,12 @@ class Map(object):
             :class:`~canopen.pdo.Map`.
         """
         self.callbacks.append(callback)
-
+    
+    def clear_callbacks(self):
+        """Clear the list of callbacks.
+        """
+        self.callbacks = []
+     
     def read(self):
         """Read PDO configuration for this map using SDO."""
         cob_id = self.com_record[1].raw

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -89,6 +89,7 @@ class Node402(Node):
         # Use register as to stay manufacturer agnostic
         self.pdo.tx[1].add_variable(0x6041)
         # add callback to listen to TPDO1 and change 402 state
+        self.pdo.tx[1].clear_callbacks()
         self.pdo.tx[1].add_callback(self.powerstate_402.on_PDO1_callback)
         self.pdo.tx[1].trans_type = 255
         self.pdo.tx[1].enabled = True
@@ -97,6 +98,11 @@ class Node402(Node):
 
     def add_callback_402_state(self, state, cb):
         self.callbacks_402[state].append(cb)
+
+    def clear_402_callbacks(self):
+        print "clearing 402 callbacks"
+        for key, (value, cblist) in enumerate(self.callbacks_402.iteritems()):
+            cblist = []
 
     def execute_callbacks_402(self, state):
         #cb_list = self.callbacks_402[state]

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -119,10 +119,7 @@ class PowerStateMachine(object):
         - 'QUICK STOP ACTIVE'
 
         """
-        if self._state in POWER_STATES_402.values():
-            return POWER_STATES_402[self._state]
-        else:
-            return self._state
+        return self._state
 
     @state.setter
     def state(self, new_state):


### PR DESCRIPTION
This PR is to start feedback for bringing in Homing functionality and 402 state change callbacks
I've also added callbacks so that when a specific 402 profile state is reached, code can be executed. I use this mainly to push certain functions on a deque for async execution.

- I need to look into removing obsolete commented lines (I've spotted one at least)
- at this point I should still add some documentation additions