### PR TITLE
Extension to local-node 

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import threading
+import struct
 
 try:
     import can
@@ -42,6 +43,7 @@ class Network(collections.MutableMapping):
         self.notifier = None
         self.nodes = {}
         self.subscribers = {}
+        self.nmt_cmd_subscribers = {}
         self.send_lock = threading.Lock()
         self.sync = SyncProducer(self)
         self.time = TimeProducer(self)
@@ -68,6 +70,23 @@ class Network(collections.MutableMapping):
     def unsubscribe(self, can_id):
         """Stop listening for message."""
         del self.subscribers[can_id]
+
+    def subscribe_nmt_cmd(self, node_id, callback):
+        """Listen for nmt commands to a specific node.
+
+        Only one callback can be used per Node ID.
+
+        :param int node_id:
+            The Node ID to listen for.
+        :param callback:
+            Function to call when message is received.
+        """
+        self.nmt_cmd_subscribers[node_id] = callback
+
+    def unsubscribe_nmt_cmd(self, node_id):
+        """Stop listening for nmt commands."""
+        del self.nmt_cmd_subscribers[node_id]
+
 
     def connect(self, *args, **kwargs):
         """Connect to CAN bus using python-can.
@@ -197,10 +216,19 @@ class Network(collections.MutableMapping):
         :param float timestamp:
             Timestamp of the message, preferably as a Unix timestamp
         """
-        if can_id in self.subscribers:
-            callback = self.subscribers[can_id]
-            callback(can_id, data, timestamp)
-        self.scanner.on_message_received(can_id)
+
+        # NMT commands is sent out with can_id = 0
+        if can_id == 0:
+            (cmd, node_id) = struct.unpack_from("<BB", data)
+
+            if node_id in self.nmt_cmd_subscribers:
+                callback = self.nmt_cmd_subscribers[node_id]
+                callback(node_id, data, timestamp)
+        else:
+            if can_id in self.subscribers:
+                callback = self.subscribers[can_id]
+                callback(can_id, data, timestamp)
+            self.scanner.on_message_received(can_id)
 
     def __getitem__(self, node_id):
         return self.nodes[node_id]

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -219,11 +219,17 @@ class Network(collections.MutableMapping):
 
         # NMT commands is sent out with can_id = 0
         if can_id == 0:
-            (cmd, node_id) = struct.unpack_from("<BB", data)
+            (_, node_id) = struct.unpack_from("<BB", data)
 
-            if node_id in self.nmt_cmd_subscribers:
+            # Broadcast has node-id = 0
+            if node_id == 0:
+                for subscriber_id in self.nmt_cmd_subscribers:
+                    callback = self.nmt_cmd_subscribers[subscriber_id]
+                    callback(data, timestamp)
+
+            elif node_id in self.nmt_cmd_subscribers:
                 callback = self.nmt_cmd_subscribers[node_id]
-                callback(node_id, data, timestamp)
+                callback(data, timestamp)
         else:
             if can_id in self.subscribers:
                 callback = self.subscribers[can_id]

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -151,6 +151,13 @@ class NmtSlave(object):
         self._heartbeat_time_ms = 0
         self._local_node = local_node
 
+    def on_command(self, can_id, data, timestamp):
+        (cmd, node_id) = struct.unpack_from("<BB", data)
+
+        if node_id == self._id:
+            logger.info("Received command %d", cmd)
+            self.state = NMT_STATES[COMMAND_TO_STATE[cmd]]
+
     @property
     def state(self):
         """Attribute to get or set node's state as a string.
@@ -177,7 +184,7 @@ class NmtSlave(object):
             new_nmt_state = COMMAND_TO_STATE[NMT_COMMANDS[new_state]]
 
             logger.info("New NMT state %s, old state %s",
-                    NMT_STATES[new_nmt_state], NMT_STATES[self._state])
+                        NMT_STATES[new_nmt_state], NMT_STATES[self._state])
 
             # The heartbeat service should start on the transition
             # between INITIALIZING and PRE-OPERATIONAL state
@@ -216,7 +223,7 @@ class NmtSlave(object):
         while not stop_event.is_set():
             stop_event.wait(self._heartbeat_time_ms/1000)
             logger.debug("Sending heartbeat, NMT state is  %s", NMT_STATES[self._state])
-            
+
             try:
                 self.network.send_message(1792 + self._id, [self._state])
             except CanError as e:

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -149,7 +149,7 @@ class NmtSlave(object):
         self._thread_stop = None
         self._heartbeat_time_ms = 0
 
-    def start_hearbeat(self, heartbeat_time_ms):
+    def start_heartbeat(self, heartbeat_time_ms):
         """Start the hearbeat service.
 
         :param int hearbeat_time

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -152,11 +152,10 @@ class NmtSlave(object):
         self._local_node = local_node
 
     def on_command(self, can_id, data, timestamp):
-        (cmd, node_id) = struct.unpack_from("<BB", data)
+        (cmd, _) = struct.unpack_from("<BB", data)
 
-        if node_id == self._id:
-            logger.info("Received command %d", cmd)
-            self.state = NMT_STATES[COMMAND_TO_STATE[cmd]]
+        logger.info("Node %d received command %d",can_id, cmd)
+        self.state = NMT_STATES[COMMAND_TO_STATE[cmd]]
 
     @property
     def state(self):

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -188,7 +188,7 @@ class NmtSlave(object):
 
             # The heartbeat service should start on the transition
             # between INITIALIZING and PRE-OPERATIONAL state
-            if self._state is 0 and new_nmt_state is 127:
+            if self._state == 0 and new_nmt_state == 127:
                 self.stop_heartbeat()
                 heartbeat_time_ms = self._local_node.sdo[0x1017].raw
                 self.start_heartbeat(heartbeat_time_ms)

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -3,6 +3,7 @@ import logging
 import struct
 import time
 
+from .network import CanError
 
 logger = logging.getLogger(__name__)
 
@@ -215,4 +216,9 @@ class NmtSlave(object):
         while not stop_event.is_set():
             stop_event.wait(self._heartbeat_time_ms/1000)
             logger.debug("Sending heartbeat, NMT state is  %s", NMT_STATES[self._state])
-            self.network.send_message(1792 + self._id, [self._state])
+            
+            try:
+                self.network.send_message(1792 + self._id, [self._state])
+            except CanError as e:
+                # We will just try again
+                logger.info("Failed to send heartbeat due to: %s", str(e))

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -202,14 +202,18 @@ class NmtSlave(object):
         """Start the hearbeat service.
 
         :param int hearbeat_time
-            The heartbeat time in ms
+            The heartbeat time in ms. If the heartbeat time is 0
+            the heartbeating will not start.
         """
         self._heartbeat_time_ms = heartbeat_time_ms
-        logger.info("Start the hearbeat timer, interval is %d ms", self._heartbeat_time_ms)
-        self._thread_stop = threading.Event()
-        self._timer_thread = threading.Thread(target=self.send_heartbeat, args=(self._thread_stop,))
-        self._timer_thread.daemon = True
-        self._timer_thread.start()
+
+        if heartbeat_time_ms > 0:
+            logger.info("Start the hearbeat timer, interval is %d ms", self._heartbeat_time_ms)
+            self._thread_stop = threading.Event()
+            self._timer_thread = threading.Thread(target=self.send_heartbeat,
+                                                  args=(self._thread_stop,))
+            self._timer_thread.daemon = True
+            self._timer_thread.start()
 
     def stop_heartbeat(self):
         """Stop the hearbeat service."""

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -151,10 +151,10 @@ class NmtSlave(object):
         self._heartbeat_time_ms = 0
         self._local_node = local_node
 
-    def on_command(self, can_id, data, timestamp):
+    def on_command(self, data, timestamp):
         (cmd, _) = struct.unpack_from("<BB", data)
 
-        logger.info("Node %d received command %d",can_id, cmd)
+        logger.info("Node %d received command %d", self._id, cmd)
         self.state = NMT_STATES[COMMAND_TO_STATE[cmd]]
 
     @property

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -21,11 +21,11 @@ class LocalNode(BaseNode):
         self.sdo.network = network
         self.nmt.network = network
         network.subscribe(self.sdo.rx_cobid, self.sdo.on_request)
-        network.subscribe(0, self.nmt.on_command)
+        network.subscribe_nmt_cmd(self.id, self.nmt.on_command)
 
     def remove_network(self):
         self.network.unsubscribe(self.sdo.rx_cobid)
-        self.network.unsubscribe(0)
+        self.network.unsubscribe_nmt_cmd(self.id)
         self.network = None
         self.sdo.network = None
         self.nmt.network = None

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -39,9 +39,10 @@ class LocalNode(BaseNode):
                 # This is a read callback. If we return none
                 # the data will be read from local storage
                 return None
-            elif kwargs["data"] == 0:
-                self.nmt.stop_heartbeat()
             else:
                 (hearbeat_time, ) = struct.unpack_from("<H", kwargs["data"])
-                self.nmt.start_heartbeat(hearbeat_time)
+                if hearbeat_time == 0:
+                    self.nmt.stop_heartbeat()
+                else:
+                    self.nmt.start_heartbeat(hearbeat_time)
             return 0x0201

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -13,7 +13,7 @@ class LocalNode(BaseNode):
         self.callbacks = []
 
         self.sdo = SdoServer(0x600 + self.id, 0x580 + self.id, self)
-        self.nmt = NmtSlave(self.id)
+        self.nmt = NmtSlave(self.id, self)
         self.add_callback(self._producer_hearbeat_time_callback)
 
     def associate_network(self, network):

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -21,9 +21,11 @@ class LocalNode(BaseNode):
         self.sdo.network = network
         self.nmt.network = network
         network.subscribe(self.sdo.rx_cobid, self.sdo.on_request)
+        network.subscribe(0, self.nmt.on_command)
 
     def remove_network(self):
         self.network.unsubscribe(self.sdo.rx_cobid)
+        self.network.unsubscribe(0)
         self.network = None
         self.sdo.network = None
         self.nmt.network = None

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -41,5 +41,5 @@ class LocalNode(BaseNode):
                 self.nmt.stop_heartbeat()
             else:
                 (hearbeat_time, ) = struct.unpack_from("<H", kwargs["data"])
-                self.nmt.start_hearbeat(hearbeat_time)
+                self.nmt.start_heartbeat(hearbeat_time)
             return 0x0201

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -1,5 +1,7 @@
+import struct
 from .base import BaseNode
 from ..sdo import SdoServer
+from ..nmt import NmtSlave
 
 
 class LocalNode(BaseNode):
@@ -11,16 +13,33 @@ class LocalNode(BaseNode):
         self.callbacks = []
 
         self.sdo = SdoServer(0x600 + self.id, 0x580 + self.id, self)
+        self.nmt = NmtSlave(self.id)
+        self.add_callback(self._producer_hearbeat_time_callback)
 
     def associate_network(self, network):
         self.network = network
         self.sdo.network = network
+        self.nmt.network = network
         network.subscribe(self.sdo.rx_cobid, self.sdo.on_request)
 
     def remove_network(self):
         self.network.unsubscribe(self.sdo.rx_cobid)
         self.network = None
         self.sdo.network = None
+        self.nmt.network = None
 
     def add_callback(self, callback):
         self.callbacks.append(callback)
+
+    def _producer_hearbeat_time_callback(self, **kwargs):
+        if kwargs["index"] == 0x1017:
+            if kwargs["data"] is None:
+                # This is a read callback. If we return none
+                # the data will be read from local storage
+                return None
+            elif kwargs["data"] == 0:
+                self.nmt.stop_heartbeat()
+            else:
+                (hearbeat_time, ) = struct.unpack_from("<H", kwargs["data"])
+                self.nmt.start_hearbeat(hearbeat_time)
+            return 0x0201

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -45,4 +45,6 @@ class LocalNode(BaseNode):
                     self.nmt.stop_heartbeat()
                 else:
                     self.nmt.start_heartbeat(hearbeat_time)
-            return 0x0201
+
+                # Return True to indicate that we have handled the callback
+                return True

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -40,7 +40,7 @@ def import_eds(source, node_id):
         match = re.match(r"^[0-9A-Fa-f]{4}$", section)
         if match is not None:
             index = int(section, 16)
-            name = eds.get(section, "ParameterName")
+            name = eds.get(section, "ParameterName", raw=True)
             object_type = int(eds.get(section, "ObjectType"), 0)
 
             if object_type == VAR:

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -1,6 +1,7 @@
 import re
 import io
 import logging
+import copy
 try:
     from configparser import ConfigParser
 except ImportError:
@@ -74,6 +75,19 @@ def import_eds(source, node_id):
                 var = build_variable(eds, section, index, subindex)
                 entry.add_member(var)
 
+        # Match [index]Name
+        match = re.match(r"^([0-9A-Fa-f]{4})Name", section)
+        if match is not None:
+            index = int(match.group(1), 16)
+            num_of_entries = int(eds.get(section, "NrOfEntries"))
+            entry = od[index]
+            # For CompactSubObj index 1 is were we find the variable
+            src_var = od[index][1]
+            for subindex in range(1, num_of_entries + 1):
+                var = copy_variable(eds, section, subindex, src_var)
+                if var is not None:
+                    entry.add_member(var)
+
     return od
 
 
@@ -128,4 +142,12 @@ def build_variable(eds, section, index, subindex=0):
                 var.default = int(eds.get(section, "DefaultValue"), 0)
         except ValueError:
             pass
+    return var
+
+def copy_variable(eds, section, subindex, src_var):
+    name = eds.get(section, str(subindex))
+    var = copy.copy(src_var)
+    # It is only the name and subindex that varies
+    var.name = name
+    var.subindex = subindex
     return var

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -120,7 +120,12 @@ def build_variable(eds, section, index, subindex=0):
             pass
     if eds.has_option(section, "DefaultValue"):
         try:
-            var.default = int(eds.get(section, "DefaultValue"), 0)
+            if var.data_type is objectdictionary.VISIBLE_STRING:
+                var.default = eds.get(section, "DefaultValue")
+            elif var.data_type is objectdictionary.REAL32:
+                var.default = float(eds.get(section, "DefaultValue"))
+            else:
+                var.default = int(eds.get(section, "DefaultValue"), 0)
         except ValueError:
             pass
     return var

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -111,7 +111,7 @@ def import_from_node(node_id, network):
 
 
 def build_variable(eds, section, index, subindex=0):
-    name = eds.get(section, "ParameterName")
+    name = eds.get(section, "ParameterName", raw=True)
     var = objectdictionary.Variable(name, index, subindex)
     var.data_type = int(eds.get(section, "DataType"), 0)
     var.access_type = eds.get(section, "AccessType").lower()

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -3,9 +3,9 @@ import io
 import logging
 import copy
 try:
-    from configparser import ConfigParser
+    from configparser import RawConfigParser
 except ImportError:
-    from ConfigParser import RawConfigParser as ConfigParser
+    from ConfigParser import RawConfigParser
 from canopen import objectdictionary
 from canopen.sdo import SdoClient
 
@@ -19,7 +19,7 @@ RECORD = 9
 
 
 def import_eds(source, node_id):
-    eds = ConfigParser()
+    eds = RawConfigParser()
     if hasattr(source, "read"):
         fp = source
     else:
@@ -41,7 +41,7 @@ def import_eds(source, node_id):
         match = re.match(r"^[0-9A-Fa-f]{4}$", section)
         if match is not None:
             index = int(section, 16)
-            name = eds.get(section, "ParameterName", raw=True)
+            name = eds.get(section, "ParameterName")
             object_type = int(eds.get(section, "ObjectType"), 0)
 
             if object_type == VAR:
@@ -111,7 +111,7 @@ def import_from_node(node_id, network):
 
 
 def build_variable(eds, section, index, subindex=0):
-    name = eds.get(section, "ParameterName", raw=True)
+    name = eds.get(section, "ParameterName")
     var = objectdictionary.Variable(name, index, subindex)
     var.data_type = int(eds.get(section, "DataType"), 0)
     var.access_type = eds.get(section, "AccessType").lower()

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -134,9 +134,9 @@ def build_variable(eds, section, index, subindex=0):
             pass
     if eds.has_option(section, "DefaultValue"):
         try:
-            if var.data_type is objectdictionary.VISIBLE_STRING:
+            if var.data_type in objectdictionary.DATA_TYPES:
                 var.default = eds.get(section, "DefaultValue")
-            elif var.data_type is objectdictionary.REAL32:
+            elif var.data_type in objectdictionary.FLOAT_TYPES:
                 var.default = float(eds.get(section, "DefaultValue"))
             else:
                 var.default = int(eds.get(section, "DefaultValue"), 0)

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -44,6 +44,10 @@ class SdoServer(SdoBase):
                 self.init_download(data)
             elif ccs == REQUEST_SEGMENT_DOWNLOAD:
                 self.segmented_download(command, data)
+            elif ccs == REQUEST_BLOCK_UPLOAD:
+                self.block_upload(data)
+            elif ccs == REQUEST_BLOCK_DOWNLOAD:
+                self.block_download(data)
         except SdoAbortedError as exc:
             self.abort(exc.code)
         except KeyError as exc:
@@ -100,6 +104,18 @@ class SdoServer(SdoBase):
         response[0] = res_command
         response[1:1 + size] = data
         self.send_response(response)
+
+    def block_upload(self, data):
+        # We currently don't support BLOCK UPLOAD
+        # according to CIA301 the server is allowed
+        # to switch to regular upload
+        logger.info("Received block upload, switch to regular SDO upload")
+        self.init_upload(data)
+
+    def block_download(self, data):
+        # We currently don't support BLOCK DOWNLOAD
+        logger.error("Block download is not supported")
+        self.abort(0x05040001)
 
     def init_download(self, request):
         command, index, subindex = SDO_STRUCT.unpack_from(request)

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -209,6 +209,7 @@ class SdoServer(SdoBase):
             # Try default value
             if obj.default is None:
                 # Resource not available
+                logger.info("Resource unavailable for 0x%X:%d", index, subindex)
                 raise SdoAbortedError(0x060A0023)
             return obj.encode_raw(obj.default)
 

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -130,6 +130,7 @@ ParameterName=Manufacturer device name
 ObjectType=0x7
 DataType=0x0009
 AccessType=const
+DefaultValue=TEST DEVICE
 PDOMapping=0
 
 [1017]
@@ -791,3 +792,13 @@ ObjectType=0x7
 DataType=0x0009
 AccessType=rw
 PDOMapping=0
+
+[3002]
+ParameterName=Sensor Sampling Rate (Hz)
+ObjectType=0x7
+DataType=0x0008
+AccessType=ro
+DefaultValue=5.2
+PDOMapping=0
+LowLimit=4.5
+ParameterValue=5.200000

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -810,3 +810,18 @@ DataType=0x0008
 AccessType=rw
 DefaultValue=
 PDOMapping=0
+
+[3004]
+CompactSubObj=3
+ParameterName=Sensor Status
+ObjectType=8
+DataType=0x0006
+AccessType=ro
+DefaultValue=3
+PDOMapping=0
+
+[3004Name]
+NrOfEntries=3
+1=Sensor Status 1
+2=Sensor Status 2
+3=Sensor Status 3

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -825,3 +825,12 @@ NrOfEntries=3
 1=Sensor Status 1
 2=Sensor Status 2
 3=Sensor Status 3
+
+[3006]
+CompactSubObj=24
+ParameterName=Valve 1 % Open
+ObjectType=8
+DataType=0x0008
+AccessType=rw
+DefaultValue=
+PDOMapping=0

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -802,3 +802,11 @@ DefaultValue=5.2
 PDOMapping=0
 LowLimit=4.5
 ParameterValue=5.200000
+
+[3003]
+ParameterName=Valve % open
+ObjectType=0x8
+DataType=0x0008
+AccessType=rw
+DefaultValue=
+PDOMapping=0

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -56,7 +56,7 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(var.data_type, canopen.objectdictionary.UNSIGNED32)
         self.assertEqual(var.access_type, 'ro')
 
-    def test_explisit_name_subobj(self):
+    def test_explicit_name_subobj(self):
         name = self.od[0x3004].name
         self.assertEqual(name, 'Sensor Status')
         name = self.od[0x3004][1].name
@@ -65,3 +65,7 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(name, 'Sensor Status 3')
         value = self.od[0x3004][3].default
         self.assertEqual(value, 3)
+
+    def test_parameter_name_with_percent(self):
+        name = self.od[0x3003].name
+        self.assertEqual(name, 'Valve % open')

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -69,3 +69,7 @@ class TestEDS(unittest.TestCase):
     def test_parameter_name_with_percent(self):
         name = self.od[0x3003].name
         self.assertEqual(name, 'Valve % open')
+
+    def test_compact_subobj_parameter_name_with_percent(self):
+        name = self.od[0x3006].name
+        self.assertEqual(name, 'Valve 1 % Open')

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -55,3 +55,13 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(var.subindex, 5)
         self.assertEqual(var.data_type, canopen.objectdictionary.UNSIGNED32)
         self.assertEqual(var.access_type, 'ro')
+
+    def test_explisit_name_subobj(self):
+        name = self.od[0x3004].name
+        self.assertEqual(name, 'Sensor Status')
+        name = self.od[0x3004][1].name
+        self.assertEqual(name, 'Sensor Status 1')
+        name = self.od[0x3004][3].name
+        self.assertEqual(name, 'Sensor Status 3')
+        value = self.od[0x3004][3].default
+        self.assertEqual(value, 3)

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -34,6 +34,14 @@ class TestSDO(unittest.TestCase):
         vendor_id = self.remote_node.sdo["Producer heartbeat time"].raw
         self.assertEqual(vendor_id, 0x99)
 
+    def test_expedited_upload_default_value_visible_string(self):
+        device_name = self.remote_node.sdo["Manufacturer device name"].raw
+        self.assertEqual(device_name, b"TEST DEVICE")
+
+    def test_expedited_upload_default_value_real(self):
+        sampling_rate = self.remote_node.sdo["Sensor Sampling Rate (Hz)"].raw
+        self.assertAlmostEqual(sampling_rate, 5.2, places=2)
+
     def test_segmented_upload(self):
         self.local_node.sdo["Manufacturer device name"].raw = "Some cool device"
         device_name = self.remote_node.sdo["Manufacturer device name"].data

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -25,6 +25,10 @@ class TestSDO(unittest.TestCase):
         cls.network2.connect("test", bustype="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
+        cls.remote_node2 = cls.network1.add_node(3, EDS_PATH)
+
+        cls.local_node2 = cls.network2.create_node(3, EDS_PATH)
+
     @classmethod
     def tearDownClass(cls):
         cls.network1.disconnect()
@@ -107,6 +111,30 @@ class TestSDO(unittest.TestCase):
         # before we do the check
         time.sleep(0.1)
         slave_state = self.local_node.nmt.state
+        self.assertEqual(slave_state, 'OPERATIONAL')
+
+    def test_two_nodes_on_the_bus(self):
+        self.local_node.sdo["Manufacturer device name"].raw = "Some cool device"
+        device_name = self.remote_node.sdo["Manufacturer device name"].data
+        self.assertEqual(device_name, b"Some cool device")
+
+        self.local_node2.sdo["Manufacturer device name"].raw = "Some cool device2"
+        device_name = self.remote_node2.sdo["Manufacturer device name"].data
+        self.assertEqual(device_name, b"Some cool device2")
+
+    def test_start_two_remote_nodes(self):
+        self.remote_node.nmt.state = 'OPERATIONAL'
+        # Line below is just so that we are sure the client have received the command
+        # before we do the check
+        time.sleep(0.1)
+        slave_state = self.local_node.nmt.state
+        self.assertEqual(slave_state, 'OPERATIONAL')
+
+        self.remote_node2.nmt.state = 'OPERATIONAL'
+        # Line below is just so that we are sure the client have received the command
+        # before we do the check
+        time.sleep(0.1)
+        slave_state = self.local_node2.nmt.state
         self.assertEqual(slave_state, 'OPERATIONAL')
 
     def test_abort(self):

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -137,7 +137,7 @@ class TestSDO(unittest.TestCase):
         slave_state = self.local_node2.nmt.state
         self.assertEqual(slave_state, 'OPERATIONAL')
 
-    def test_start_two_remote_nodes_using_broadcast(self):
+    def test_stop_two_remote_nodes_using_broadcast(self):
         # This is a NMT broadcast "Stop remote node"
         # ie. set the node in STOPPED state
         self.network1.send_message(0, [2, 0])

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -3,7 +3,7 @@ import unittest
 import canopen
 import logging
 
-#logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 
 EDS_PATH = os.path.join(os.path.dirname(__file__), 'sample.eds')
@@ -83,6 +83,9 @@ class TestSDO(unittest.TestCase):
         self.assertEqual(state, canopen.nmt.NMT_STATES[127])
 
     def test_nmt_state_initializing_to_preoper(self):
+        # Initialize the heartbeat timer
+        self.local_node.sdo["Producer heartbeat time"].raw = 1000
+        self.local_node.nmt.stop_heartbeat()
         # This transition shall start the heartbeating
         self.local_node.nmt.state = 'INITIALISING'
         self.local_node.nmt.state = 'PRE-OPERATIONAL'

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -137,6 +137,19 @@ class TestSDO(unittest.TestCase):
         slave_state = self.local_node2.nmt.state
         self.assertEqual(slave_state, 'OPERATIONAL')
 
+    def test_start_two_remote_nodes_using_broadcast(self):
+        # This is a NMT broadcast "Stop remote node"
+        # ie. set the node in STOPPED state
+        self.network1.send_message(0, [2, 0])
+
+        # Line below is just so that we are sure the slaves have received the command
+        # before we do the check
+        time.sleep(0.1)
+        slave_state = self.local_node.nmt.state
+        self.assertEqual(slave_state, 'STOPPED')
+        slave_state = self.local_node2.nmt.state
+        self.assertEqual(slave_state, 'STOPPED')
+
     def test_abort(self):
         with self.assertRaises(canopen.SdoAbortedError) as cm:
             _ = self.remote_node.sdo.upload(0x1234, 0)

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -51,7 +51,7 @@ class TestSDO(unittest.TestCase):
 
     def test_expedited_upload_default_value_visible_string(self):
         device_name = self.remote_node.sdo["Manufacturer device name"].raw
-        self.assertEqual(device_name, b"TEST DEVICE")
+        self.assertEqual(device_name, "TEST DEVICE")
 
     def test_expedited_upload_default_value_real(self):
         sampling_rate = self.remote_node.sdo["Sensor Sampling Rate (Hz)"].raw

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import canopen
 import logging
+import time
 
 # logging.basicConfig(level=logging.DEBUG)
 
@@ -97,14 +98,14 @@ class TestSDO(unittest.TestCase):
         self.remote_node.sdo.abort(0x05040003)
         # Line below is just so that we are sure the client have received the abort
         # before we do the check
-        self.remote_node.sdo["Manufacturer device name"].raw = "Another cool device"
+        time.sleep(0.1)
         self.assertEqual(self.local_node.sdo.last_received_error, 0x05040003)
 
     def test_start_remote_node(self):
         self.remote_node.nmt.state = 'OPERATIONAL'
         # Line below is just so that we are sure the client have received the command
         # before we do the check
-        self.remote_node.sdo["Manufacturer device name"].raw = "Another cool device"
+        time.sleep(0.1)
         slave_state = self.local_node.nmt.state
         self.assertEqual(slave_state, 'OPERATIONAL')
 

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -97,6 +97,14 @@ class TestSDO(unittest.TestCase):
         self.remote_node.sdo["Manufacturer device name"].raw = "Another cool device"
         self.assertEqual(self.local_node.sdo.last_received_error, 0x05040003)
 
+    def test_start_remote_node(self):
+        self.remote_node.nmt.state = 'OPERATIONAL'
+        # Line below is just so that we are sure the client have received the command
+        # before we do the check
+        self.remote_node.sdo["Manufacturer device name"].raw = "Another cool device"
+        slave_state = self.local_node.nmt.state
+        self.assertEqual(slave_state, 'OPERATIONAL')
+
     def test_abort(self):
         with self.assertRaises(canopen.SdoAbortedError) as cm:
             _ = self.remote_node.sdo.upload(0x1234, 0)

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -82,6 +82,13 @@ class TestSDO(unittest.TestCase):
         # to PRE-OPERATIONAL (127)
         self.assertEqual(state, canopen.nmt.NMT_STATES[127])
 
+    def test_receive_abort_request(self):
+        self.remote_node.sdo.abort(0x05040003)
+        # Line below is just so that we are sure the client have received the abort
+        # before we do the check
+        self.remote_node.sdo["Manufacturer device name"].raw = "Another cool device"
+        self.assertEqual(self.local_node.sdo.last_received_error, 0x05040003)
+
     def test_abort(self):
         with self.assertRaises(canopen.SdoAbortedError) as cm:
             _ = self.remote_node.sdo.upload(0x1234, 0)

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -73,7 +73,7 @@ class TestSDO(unittest.TestCase):
         self.assertEqual(device_name, b"Another cool device")
 
     def test_slave_send_heartbeat(self):
-        # Setting the heartbeat time should trigger hearbeating 
+        # Setting the heartbeat time should trigger hearbeating
         # to start
         self.remote_node.sdo["Producer heartbeat time"].raw = 1000
         state = self.remote_node.nmt.wait_for_heartbeat()
@@ -81,6 +81,14 @@ class TestSDO(unittest.TestCase):
         # The NMT master will change the state INITIALISING (0)
         # to PRE-OPERATIONAL (127)
         self.assertEqual(state, canopen.nmt.NMT_STATES[127])
+
+    def test_nmt_state_initializing_to_preoper(self):
+        # This transition shall start the heartbeating
+        self.local_node.nmt.state = 'INITIALISING'
+        self.local_node.nmt.state = 'PRE-OPERATIONAL'
+        state = self.remote_node.nmt.wait_for_heartbeat()
+        self.local_node.nmt.stop_heartbeat()
+        self.assertEqual(state, 'PRE-OPERATIONAL')
 
     def test_receive_abort_request(self):
         self.remote_node.sdo.abort(0x05040003)

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -40,7 +40,7 @@ class TestSDO(unittest.TestCase):
             self.remote_node.sdo[0x1008].open('r', block_transfer=True)
         # We get this since the sdo client don't support the switch
         # from block upload to expedite upload
-        self.assertTrue("Unexpected response 0x41" in context.exception)
+        self.assertEqual("Unexpected response 0x41", str(context.exception))
 
     def test_block_download_not_supported(self):
         data = b"TEST DEVICE"

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -119,6 +119,11 @@ class TestSDO(unittest.TestCase):
         # Should be Subindex does not exist
         self.assertEqual(cm.exception.code, 0x06090011)
 
+        with self.assertRaises(canopen.SdoAbortedError) as cm:
+            _ = self.remote_node.sdo[0x1001].data
+        # Should be Resource not available
+        self.assertEqual(cm.exception.code, 0x060A0023)
+
     def _some_callback(self, **kwargs):
         self._kwargs = kwargs
         if kwargs["index"] == 0x1003:

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -34,6 +34,21 @@ class TestSDO(unittest.TestCase):
         vendor_id = self.remote_node.sdo["Producer heartbeat time"].raw
         self.assertEqual(vendor_id, 0x99)
 
+    def test_block_upload_switch_to_expedite_upload(self):
+        with self.assertRaises(canopen.SdoCommunicationError) as context:
+            self.remote_node.sdo[0x1008].open('r', block_transfer=True)
+        # We get this since the sdo client don't support the switch
+        # from block upload to expedite upload
+        self.assertTrue("Unexpected response 0x41" in context.exception)
+
+    def test_block_download_not_supported(self):
+        data = b"TEST DEVICE"
+        with self.assertRaises(canopen.SdoAbortedError) as context:
+            self.remote_node.sdo[0x1008].open('wb',
+                                              size=len(data),
+                                              block_transfer=True)
+        self.assertEqual(context.exception.code, 0x05040001)
+
     def test_expedited_upload_default_value_visible_string(self):
         device_name = self.remote_node.sdo["Manufacturer device name"].raw
         self.assertEqual(device_name, b"TEST DEVICE")

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -3,7 +3,7 @@ import unittest
 import canopen
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+#logging.basicConfig(level=logging.DEBUG)
 
 
 EDS_PATH = os.path.join(os.path.dirname(__file__), 'sample.eds')


### PR DESCRIPTION
I have extended the canopen slave functionality (local-node). The added functionality is enough to make a working canopen slave that is accepted by a canopen master based on the Port stack. An example of a simple working canopen simulator using this extended functionality can be found here: https://github.com/fredrikhoyer/canslave_sim

The main extensions that I have added are:
- Added a NmtSlave class with functionality to handle Heartbeat service, reception of NMT commands and handling of NMT state
- Extended Local Node to use the new NmtSlave class
- Extend the Sdo Server so that it to some extent handle block upload/download and request aborted
- Extended the EDS parsing so that it handles some of the real world eds files that I have
