### PR TITLE
Ignore extra data bytes when parsing variables.

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -285,6 +285,9 @@ class Variable(object):
             return data.decode("utf_16_le")
         elif self.data_type in self.STRUCT_TYPES:
             try:
+                needed_bytes = self.STRUCT_TYPES[self.data_type].size
+                if needed_bytes < len(data):
+                    data = bytearray(data)[0:needed_bytes]
                 value, = self.STRUCT_TYPES[self.data_type].unpack(data)
                 return value
             except struct.error:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -287,7 +287,7 @@ class Variable(object):
             try:
                 needed_bytes = self.STRUCT_TYPES[self.data_type].size
                 if needed_bytes < len(data):
-                    data = bytearray(data)[0:needed_bytes]
+                    data = data[0:needed_bytes]
                 value, = self.STRUCT_TYPES[self.data_type].unpack(data)
                 return value
             except struct.error:


### PR DESCRIPTION
Some controllers send all PDOs with DLC=8 or specify wrong sizes in
SDO responses.  This is a catch-all solution to silently discard
unexpected extra bytes.

This is my hacky solution in part for #34, because the used Curtis Instruments motor controllers don't set the message length correctly in all cases.