### PR TITLE
Provide a way to inhibit COB ID subscription for PDOs.

### DIFF
--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -165,6 +165,8 @@ class Map(object):
         self.period = None
         self.callbacks = []
         self.receive_condition = threading.Condition()
+        #: Should this object subscribe to the COB ID
+        self.subscribe = True
         self.is_received = False
         self._task = None
 
@@ -232,6 +234,8 @@ class Map(object):
             :class:`~canopen.pdo.Map`.
         """
         self.callbacks.append(callback)
+        # Ensure message handler is registered for our COB ID when saving
+        self.subscribe = True
 
     def read(self):
         """Read PDO configuration for this map using SDO."""
@@ -268,7 +272,8 @@ class Map(object):
             size = value & 0xFF
             self.add_variable(index, subindex, size)
 
-        if self.enabled:
+        if self.enabled and self.subscribe:
+            assert self.cob_id not in self.pdo_node.network.subscribers
             self.pdo_node.network.subscribe(self.cob_id, self.on_message)
 
     def save(self):
@@ -308,7 +313,9 @@ class Map(object):
         if self.enabled:
             logger.info("Enabling PDO")
             self.com_record[1].raw = self.cob_id
-            self.pdo_node.network.subscribe(self.cob_id, self.on_message)
+            if self.subscribe:
+                assert self.cob_id not in self.pdo_node.network.subscribers
+                self.pdo_node.network.subscribe(self.cob_id, self.on_message)
 
     def clear(self):
         """Clear all variables from this map."""


### PR DESCRIPTION
Add a boolean attribute canopen.pdo.Map.subscribe which can be set to
False to avoid overwriting any previous subscriber for the same COB
ID.

If subscription is intended (default), throw an error in read() or
save() if a subscriber is already registered for the same COB ID.

Using add_callback() implicitly enables subscription, because it is
obviously necessary.

Documentation and tests are not included.  Fixes #75.