### PR TITLE
Accumulate COB subscribers into a list.

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -56,14 +56,13 @@ class Network(collections.MutableMapping):
     def subscribe(self, can_id, callback):
         """Listen for messages with a specific CAN ID.
 
-        Only one callback can be used per CAN ID.
-
         :param int can_id:
             The CAN ID to listen for.
         :param callback:
             Function to call when message is received.
         """
-        self.subscribers[can_id] = callback
+        self.subscribers.setdefault(can_id, list())
+        self.subscribers[can_id].append(callback)
 
     def unsubscribe(self, can_id):
         """Stop listening for message."""
@@ -196,8 +195,9 @@ class Network(collections.MutableMapping):
             Timestamp of the message, preferably as a Unix timestamp
         """
         if can_id in self.subscribers:
-            callback = self.subscribers[can_id]
-            callback(can_id, data, timestamp)
+            callbacks = self.subscribers[can_id]
+            for callback in callbacks:
+                callback(can_id, data, timestamp)
         self.scanner.on_message_received(can_id)
 
     def check(self):

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -62,7 +62,8 @@ class Network(collections.MutableMapping):
             Function to call when message is received.
         """
         self.subscribers.setdefault(can_id, list())
-        self.subscribers[can_id].append(callback)
+        if callback not in self.subscribers[can_id]:
+            self.subscribers[can_id].append(callback)
 
     def unsubscribe(self, can_id, callback=None):
         """Stop listening for message.

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -64,9 +64,19 @@ class Network(collections.MutableMapping):
         self.subscribers.setdefault(can_id, list())
         self.subscribers[can_id].append(callback)
 
-    def unsubscribe(self, can_id):
-        """Stop listening for message."""
-        del self.subscribers[can_id]
+    def unsubscribe(self, can_id, callback=None):
+        """Stop listening for message.
+
+        :param int can_id:
+            The CAN ID from which to unsubscribe.
+        :param callback:
+            If given, remove only this callback.  Otherwise all callbacks for
+            the CAN ID.
+        """
+        if callback is None:
+            del self.subscribers[can_id]
+        else:
+            self.subscribers[can_id].remove(callback)
 
     def connect(self, *args, **kwargs):
         """Connect to CAN bus using python-can.


### PR DESCRIPTION
The subscribers list was just a dictionary mapping each COB-ID to a
single callback function.  Extend that to use lists of callbacks,
which are called in turn.

This allows for different PDO mapping objects to be saved with the
same COB ID, without overwriting each other's on_message() callback
subscription.

One can now configure cross-communication between nodes by re-using
e.g. one node's TxPDO COB ID for another's RxPDO and calling read() or
save() for both.

Fixes #75.