### PR TITLE
Optionally specify subindex override in PDO add_variable()

### DIFF
--- a/canopen/common.py
+++ b/canopen/common.py
@@ -9,6 +9,10 @@ class Variable(object):
 
     def __init__(self, od):
         self.od = od
+        #: Holds a local, overridable copy of the Object Index
+        self.index = od.index
+        #: Holds a local, overridable copy of the Object Subindex
+        self.subindex = od.subindex
 
     def get_data(self):
         raise NotImplementedError("Variable is not readable")
@@ -63,8 +67,8 @@ class Variable(object):
         """
         value = self.od.decode_raw(self.data)
         text = "Value of %s (0x%X:%d) is %r" % (
-            self.od.name, self.od.index,
-            self.od.subindex, value)
+            self.od.name, self.index,
+            self.subindex, value)
         if value in self.od.value_descriptions:
             text += " (%s)" % self.od.value_descriptions[value]
         logger.debug(text)
@@ -73,8 +77,8 @@ class Variable(object):
     @raw.setter
     def raw(self, value):
         logger.debug("Writing %s (0x%X:%d) = %r",
-                     self.od.name, self.od.index,
-                     self.od.subindex, value)
+                     self.od.name, self.index,
+                     self.subindex, value)
         self.data = self.od.encode_raw(value)
 
     @property

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -311,8 +311,8 @@ class Map(object):
             subindex = 1
             for var in self.map:
                 logger.info("Writing %s (0x%X:%d, %d bits) to PDO map",
-                            var.name, var.od.index, var.subindex, var.length)
-                self.map_array[subindex].raw = (var.od.index << 16 |
+                            var.name, var.index, var.subindex, var.length)
+                self.map_array[subindex].raw = (var.index << 16 |
                                                 var.subindex << 8 |
                                                 var.length)
                 subindex += 1
@@ -349,7 +349,7 @@ class Map(object):
             # Custom bit length
             var.length = length
         logger.info("Adding %s (0x%X:%d, %d bits) to PDO map",
-                    var.name, var.od.index, var.subindex, var.length)
+                    var.name, var.index, var.subindex, var.length)
         self.map.append(var)
         self.length += var.length
         self._update_data_size()

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -413,10 +413,22 @@ class Variable(common.Variable):
         self.offset = None
         self.name = od.name
         self.length = len(od)
+        self._override_subindex = None
         if isinstance(od.parent, (objectdictionary.Record,
                                   objectdictionary.Array)):
             self.name = od.parent.name + "." + self.name
         common.Variable.__init__(self, od)
+
+    @property
+    def subindex(self):
+        if self._override_subindex is not None:
+            return self._override_subindex
+        else:
+            return self.od.subindex
+
+    @subindex.setter
+    def subindex(self, subindex):
+        self._override_subindex = subindex
 
     def get_data(self):
         """Reads the PDO variable from the last received message.

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -311,9 +311,9 @@ class Map(object):
             subindex = 1
             for var in self.map:
                 logger.info("Writing %s (0x%X:%d, %d bits) to PDO map",
-                            var.name, var.od.index, var.od.subindex, var.length)
+                            var.name, var.od.index, var.subindex, var.length)
                 self.map_array[subindex].raw = (var.od.index << 16 |
-                                                var.od.subindex << 8 |
+                                                var.subindex << 8 |
                                                 var.length)
                 subindex += 1
             self.map_array[0].raw = len(self.map)
@@ -346,7 +346,7 @@ class Map(object):
             # Custom bit length
             var.length = length
         logger.info("Adding %s (0x%X:%d, %d bits) to PDO map",
-                    var.name, var.od.index, var.od.subindex, var.length)
+                    var.name, var.od.index, var.subindex, var.length)
         self.map.append(var)
         self.length += var.length
         self._update_data_size()

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -341,6 +341,9 @@ class Map(object):
         :rtype: canopen.pdo.Variable
         """
         var = self._get_variable(index, subindex)
+        if subindex:
+            # Force given subindex upon variable mapping, for misguided implementations
+            var.subindex = subindex
         var.offset = self.length
         if length is not None:
             # Custom bit length

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -416,22 +416,10 @@ class Variable(common.Variable):
         self.offset = None
         self.name = od.name
         self.length = len(od)
-        self._override_subindex = None
         if isinstance(od.parent, (objectdictionary.Record,
                                   objectdictionary.Array)):
             self.name = od.parent.name + "." + self.name
         common.Variable.__init__(self, od)
-
-    @property
-    def subindex(self):
-        if self._override_subindex is not None:
-            return self._override_subindex
-        else:
-            return self.od.subindex
-
-    @subindex.setter
-    def subindex(self, subindex):
-        self._override_subindex = subindex
 
     def get_data(self):
         """Reads the PDO variable from the last received message.

--- a/canopen/sdo.py
+++ b/canopen/sdo.py
@@ -258,11 +258,11 @@ class Variable(common.Variable):
         common.Variable.__init__(self, od)
 
     def get_data(self):
-        return self.sdo_node.upload(self.od.index, self.od.subindex)
+        return self.sdo_node.upload(self.index, self.subindex)
 
     def set_data(self, data):
         force_segment = self.od.data_type == objectdictionary.DOMAIN
-        self.sdo_node.download(self.od.index, self.od.subindex, data, force_segment)
+        self.sdo_node.download(self.index, self.subindex, data, force_segment)
 
     def read(self, fmt="raw"):
         """Alternative way of reading using a function instead of attributes.
@@ -336,10 +336,10 @@ class Variable(common.Variable):
         if "r" in mode:
             if block_transfer:
                 raw_stream = BlockUploadStream(
-                    self.sdo_node, self.od.index, self.od.subindex)
+                    self.sdo_node, self.index, self.subindex)
             else:
                 raw_stream = ReadableStream(
-                    self.sdo_node, self.od.index, self.od.subindex)
+                    self.sdo_node, self.index, self.subindex)
             if buffering:
                 buffered_stream = io.BufferedReader(raw_stream, buffer_size=buffer_size)
             else:
@@ -347,10 +347,10 @@ class Variable(common.Variable):
         if "w" in mode:
             if block_transfer:
                 raw_stream = BlockDownloadStream(
-                    self.sdo_node, self.od.index, self.od.subindex, size)
+                    self.sdo_node, self.index, self.subindex, size)
             else:
                 raw_stream = WritableStream(
-                    self.sdo_node, self.od.index, self.od.subindex, size)
+                    self.sdo_node, self.index, self.subindex, size)
             if buffering:
                 buffered_stream = io.BufferedWriter(raw_stream, buffer_size=buffer_size)
             else:


### PR DESCRIPTION
If the keyword argument "subindex" is given and non-zero, a mapping
entry is generated for the given subindex instead of the one in the
object dictionary.

Although such mappings should not be valid, for some
devices it is necessary to include them when sending PDO mappings.
The one this was tested with has a fixed number of eight entries,
corresponding to each PDO data byte.  Mapping e.g. 16-bit variables is
done by entering the object index twice, with subindex 00 and 01,
respectively.  So by forcing the subindex=01, it creates a virtual OD
entry corresponding to the high byte of the 16-bit integer object.

This is obviously not convered by the standard and only needed for
broken devices.  Tested with AC motor controllers from Curtis
Instruments, Inc.