### PR TITLE
Handle zero length PDO mapping entries

### DIFF
--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -297,8 +297,8 @@ class Map(object):
             self.map_array[0].raw = 0
             subindex = 1
             for var in self.map:
-                logger.info("Writing %s (0x%X:%d) to PDO map",
-                            var.name, var.od.index, var.od.subindex)
+                logger.info("Writing %s (0x%X:%d, %d bits) to PDO map",
+                            var.name, var.od.index, var.od.subindex, var.length)
                 self.map_array[subindex].raw = (var.od.index << 16 |
                                                 var.od.subindex << 8 |
                                                 var.length)
@@ -332,8 +332,8 @@ class Map(object):
         if length is not None:
             # Custom bit length
             var.length = length
-        logger.info("Adding %s (0x%X:%d) to PDO map",
-                    var.name, var.od.index, var.od.subindex)
+        logger.info("Adding %s (0x%X:%d, %d bits) to PDO map",
+                    var.name, var.od.index, var.od.subindex, var.length)
         self.map.append(var)
         self.length += var.length
         self._update_data_size()

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -174,9 +174,10 @@ class Map(object):
         else:
             valid_values = []
             for var in self.map:
-                valid_values.append(var.name)
-                if var.name == key:
-                    return var
+                if var.length:
+                    valid_values.append(var.name)
+                    if var.name == key:
+                        return var
         raise KeyError("%s not found in map. Valid entries are %s" % (
             key, ", ".join(valid_values)))
 

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -266,7 +266,8 @@ class Map(object):
             index = value >> 16
             subindex = (value >> 8) & 0xFF
             size = value & 0xFF
-            self.add_variable(index, subindex, size)
+            if index and size:
+                self.add_variable(index, subindex, size)
 
         if self.enabled:
             self.pdo_node.network.subscribe(self.cob_id, self.on_message)


### PR DESCRIPTION
Yet another workaround for weird, broken device implementations.  I hope this one is still general enough to warrant the added complexity, though unneeded for conforming devices.  Even with monkey-patching, I saw no other way to handle these weirdos without touching python-canopen's code.

Background: Although such mappings should be discarded in `read()`, for
some devices it is necessary to include them when sending PDO
mappings.  The one this was tested with has a fixed number of eight
entries, corresponding to each PDO data byte.  Mapping e.g. 16-bit
variables is done by entering the object index twice, with subindex 00
and 01, respectively.  The actual bit length parameter is then
disregarded.

So for this library, an entry with `length=16` and `subindex=00` works
normally and second entry with `length=0` and `subindex=01` does not hurt.
The device gets both mappings when calling `save()`, though.

Note that such overriding of the `subindex=01` in an entry for basic
integer types is non-standard and currently not yet supported in this
library, but see #80.