### PR TITLE
Implement name attribute in common.Variable.

### DIFF
--- a/canopen/common.py
+++ b/canopen/common.py
@@ -9,6 +9,12 @@ class Variable(object):
 
     def __init__(self, od):
         self.od = od
+        #: Description of this variable from Object Dictionary, overridable
+        self.name = od.name
+        if isinstance(od.parent, (objectdictionary.Record,
+                                  objectdictionary.Array)):
+            # Include the parent object's name for subentries
+            self.name = od.parent.name + "." + od.name
 
     def get_data(self):
         raise NotImplementedError("Variable is not readable")

--- a/canopen/common.py
+++ b/canopen/common.py
@@ -1,6 +1,8 @@
 import logging
 import collections
 
+from . import objectdictionary
+
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -411,11 +411,7 @@ class Variable(common.Variable):
         self.msg = None
         #: Location of variable in the message in bits
         self.offset = None
-        self.name = od.name
         self.length = len(od)
-        if isinstance(od.parent, (objectdictionary.Record,
-                                  objectdictionary.Array)):
-            self.name = od.parent.name + "." + self.name
         common.Variable.__init__(self, od)
 
     def get_data(self):


### PR DESCRIPTION
Move the functionality of pdo.Variable.name to common.Variable.name.
This makes for consistent descriptions between PDO and SDO variables
when logging variable names.

Access to mapped PDO variables by name is still available using the
syntax pdo_map['Some Record 1.Some Variable'].

This commit will and should not make the same work SDO variables.
They should be looked up as before using the less ambiguous syntax
sdo['Some Record 1']['Some Variable'].  This works unchanged because
the lookup in sdo.Record.__getitem__() and sdo.Array.__getitem__()
happens in the original object dictionary, not in the sdo.Variable
realm.

See discussion in #80.