### PR TITLE
Skip PDO mappings with zero length when looking up by variable name.

### DIFF
--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -32,7 +32,7 @@ class PdoNode(collections.Mapping):
                     yield var.name
 
     def __getitem__(self, key):
-        for pdo_map in (self.rx.values() + self.tx.values()):
+        for pdo_map in self.rx.values() + self.tx.values():
             for var in pdo_map.map:
                 if var.length and var.name == key:
                     return var

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -32,11 +32,10 @@ class PdoNode(collections.Mapping):
                     yield var.name
 
     def __getitem__(self, key):
-        for pdo_maps in (self.rx, self.tx):
-            for pdo_map in pdo_maps.values():
-                for var in pdo_map.map:
-                    if var.name == key:
-                        return var
+        for pdo_map in (self.rx.values() + self.tx.values()):
+            for var in pdo_map.map:
+                if var.length and var.name == key:
+                    return var
         raise KeyError("%s was not found in any map" % key)
 
     def __len__(self):


### PR DESCRIPTION
Follow-up for commit 062c097a09c0a6de8927fc3ce184088029e4c2e9.  When
looking up variables by name through the PdoNode object instead of an
individual pdo.Map object, the zero-length variables should be skipped
just the same.

Also simplify the nested loops a bit by looping through a list
concatenation instead.

This was missed in #81.