### PR TITLE
Fix access to wrong name attribute.

### DIFF
--- a/canopen/common.py
+++ b/canopen/common.py
@@ -71,7 +71,7 @@ class Variable(object):
         """
         value = self.od.decode_raw(self.data)
         text = "Value of %s (0x%X:%d) is %r" % (
-            self.od.name, self.od.index,
+            self.name, self.od.index,
             self.od.subindex, value)
         if value in self.od.value_descriptions:
             text += " (%s)" % self.od.value_descriptions[value]
@@ -81,7 +81,7 @@ class Variable(object):
     @raw.setter
     def raw(self, value):
         logger.debug("Writing %s (0x%X:%d) = %r",
-                     self.od.name, self.od.index,
+                     self.name, self.od.index,
                      self.od.subindex, value)
         self.data = self.od.encode_raw(value)
 


### PR DESCRIPTION
Change previously missed accesses to common.Variable.od.name to just
use the new .name attribute.

Cleans up the leftovers of #82.