### PR TITLE
Add workaround for Curtis' broken PDO mapping entries.

### DIFF
--- a/canopen/node.py
+++ b/canopen/node.py
@@ -27,7 +27,7 @@ class Node(object):
 
         self.id = node_id or self.object_dictionary.node_id
 
-        #: Curtis HACK; Enable workarounds for broken implementation
+        #: Enable WORKAROUND for reversed PDO mapping entries
         self.curtis_hack = False
 
         self.sdo = SdoClient(0x600 + self.id, 0x580 + self.id, object_dictionary)

--- a/canopen/node.py
+++ b/canopen/node.py
@@ -27,6 +27,9 @@ class Node(object):
 
         self.id = node_id or self.object_dictionary.node_id
 
+        #: Curtis HACK; Enable workarounds for broken implementation
+        self.curtis_hack = False
+
         self.sdo = SdoClient(0x600 + self.id, 0x580 + self.id, object_dictionary)
         self.pdo = PdoNode(self)
         self.nmt = NmtMaster(self.id)

--- a/canopen/pdo.py
+++ b/canopen/pdo.py
@@ -276,6 +276,10 @@ class Map(object):
             index = value >> 16
             subindex = (value >> 8) & 0xFF
             size = value & 0xFF
+            if self.pdo_node.node.curtis_hack: # Curtis HACK: mixed up field order
+                index = value & 0xFFFF
+                subindex = (value >> 16) & 0xFF
+                size = (value >> 24) & 0xFF
             if index and size:
                 self.add_variable(index, subindex, size)
 
@@ -312,9 +316,14 @@ class Map(object):
             for var in self.map:
                 logger.info("Writing %s (0x%X:%d, %d bits) to PDO map",
                             var.name, var.index, var.subindex, var.length)
-                self.map_array[subindex].raw = (var.index << 16 |
-                                                var.subindex << 8 |
-                                                var.length)
+                if self.pdo_node.node.curtis_hack: # Curtis HACK: mixed up field order
+                    self.map_array[subindex].raw = (var.index |
+                                                    var.subindex << 16 |
+                                                    var.length << 24)
+                else:
+                    self.map_array[subindex].raw = (var.index << 16 |
+                                                    var.subindex << 8 |
+                                                    var.length)
                 subindex += 1
             self.map_array[0].raw = len(self.map)
             self._update_data_size()


### PR DESCRIPTION
Differring from the standard, Curtis Instruments mixed up the order of
index, subindex and length fields in their implementation of the PDO
mapping parameter records.

Introduce an attribute "curtis_hack" on the Node class to enable
interpretation of the wrong ordered entries in pdo.Map.read() and
save().

This is needed at least for the 123xE series AC motor controllers from Curtis Instruments.  Tested on the 1232E with OS version 31.