### PR TITLE
enabled a more agnostic way to access mapped objects in the PDO

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -30,9 +30,9 @@ class PdoBase(collections.Mapping):
         return iter(self.map)
 
     def __getitem__(self, key):
-        if isinstance(key, int) and key in list(set(list(range(0x1A00, 0x1A80)) + # By TPDO ID
-                                                    list(range(0x1600, 0x1680)) + # By RPDO ID
-                                                    list(range(0, 80)))):         # By PDO Index
+        if isinstance(key, int) and (0x1A00 < key < 0x1A80 or   # By TPDO ID
+                                     0x1600 < key < 0x1680 or   # By RPDO ID
+                                     0 < key < 80):             # By PDO Index
             return self.map[key]
         else:
             for pdo_map in self.map.values():

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -175,18 +175,40 @@ class Map(object):
         self.is_received = False
         self._task = None
 
+    def __getitem_by_index(self, value):
+        valid_values = []
+        for var in self.map:
+            if var.length:
+                valid_values.append(var.index)
+                if var.index == value:
+                    return var
+        raise KeyError('{0} not found in map. Valid entries are {1}'.format(
+            value, ', '.join(str(v) for v in valid_values)))
+
+    def __getitem_by_name(self, value):
+        valid_values = []
+        for var in self.map:
+            if var.length:
+                valid_values.append(var.name)
+                if var.name == value:
+                    return var
+        raise KeyError('{0} not found in map. Valid entries are {1}'.format(
+            value, ', '.join(valid_values)))
+
     def __getitem__(self, key):
+        var = None
         if isinstance(key, int):
-            return self.map[key]
+            # there is a maximum available of 8 slots per PDO map
+            if key in range(0, 8):
+                var = self.map[key]
+            else:
+                var = self.__getitem_by_index(key)
         else:
-            valid_values = []
-            for var in self.map:
-                if var.length:
-                    valid_values.append(var.name)
-                    if var.name == key:
-                        return var
-        raise KeyError("%s not found in map. Valid entries are %s" % (
-            key, ", ".join(valid_values)))
+            try:
+                var = self.__getitem_by_index(int(key, 16))
+            except ValueError:
+                var = self.__getitem_by_name(key)
+        return var
 
     def __iter__(self):
         return iter(self.map)

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -30,15 +30,14 @@ class PdoBase(collections.Mapping):
         return iter(self.map)
 
     def __getitem__(self, key):
-        if isinstance(key, int) and (0x1A00 < key < 0x1A80 or   # By TPDO ID
-                                     0x1600 < key < 0x1680 or   # By RPDO ID
-                                     0 < key < 80):             # By PDO Index
+        if isinstance(key, int) and (0x1A00 <= key <= 0x1A80 or   # By TPDO ID
+                                     0x1600 <= key <= 0x1680 or   # By RPDO ID
+                                     0 < key <= 80):              # By PDO Index
             return self.map[key]
         else:
             for pdo_map in self.map.values():
                 try:
-                    var = pdo_map[key]
-                    return var
+                    return pdo_map[key]
                 except KeyError:
                     # ignore if one specific PDO does not have the key and try the next one
                     continue

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -30,13 +30,18 @@ class PdoBase(collections.Mapping):
         return iter(self.map)
 
     def __getitem__(self, key):
-        if isinstance(key, int):
+        if isinstance(key, int) and key in list(set(range(0x1A00, 0x1A80) + # By TPDO ID
+                                                    range(0x1600, 0x1680) + # By RPDO ID
+                                                    range(0, 80))):         # By PDO Index
             return self.map[key]
         else:
             for pdo_map in self.map.values():
-                for var in pdo_map.map:
-                    if var.length and var.name == key:
-                        return var
+                try:
+                    var = pdo_map[key]
+                    return var
+                except KeyError:
+                    # ignore if one specific PDO does not have the key and try the next one
+                    continue            
         raise KeyError("PDO: {0} was not found in any map".format(key))
 
     def __len__(self):

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -30,9 +30,9 @@ class PdoBase(collections.Mapping):
         return iter(self.map)
 
     def __getitem__(self, key):
-        if isinstance(key, int) and key in list(set(range(0x1A00, 0x1A80) + # By TPDO ID
-                                                    range(0x1600, 0x1680) + # By RPDO ID
-                                                    range(0, 80))):         # By PDO Index
+        if isinstance(key, int) and key in list(set(range(0x1A00, 0x1A80) +  # By TPDO ID
+                                                    range(0x1600, 0x1680) +  # By RPDO ID
+                                                    range(0, 80))):          # By PDO Index
             return self.map[key]
         else:
             for pdo_map in self.map.values():
@@ -41,7 +41,7 @@ class PdoBase(collections.Mapping):
                     return var
                 except KeyError:
                     # ignore if one specific PDO does not have the key and try the next one
-                    continue            
+                    continue
         raise KeyError("PDO: {0} was not found in any map".format(key))
 
     def __len__(self):

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -30,9 +30,9 @@ class PdoBase(collections.Mapping):
         return iter(self.map)
 
     def __getitem__(self, key):
-        if isinstance(key, int) and key in list(set(range(0x1A00, 0x1A80) +  # By TPDO ID
-                                                    range(0x1600, 0x1680) +  # By RPDO ID
-                                                    range(0, 80))):          # By PDO Index
+        if isinstance(key, int) and key in list(set(list(range(0x1A00, 0x1A80)) + # By TPDO ID
+                                                    list(range(0x1600, 0x1680)) + # By RPDO ID
+                                                    list(range(0, 80)))):         # By PDO Index
             return self.map[key]
         else:
             for pdo_map in self.map.values():

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -10,10 +10,10 @@ class TestPDO(unittest.TestCase):
     def test_bit_mapping(self):
         node = canopen.Node(1, EDS_PATH)
         map = node.pdo.tx[1]
-        map.add_variable('INTEGER16 value')           # 0x2001
-        map.add_variable('UNSIGNED8 value', length=4) # 0x2002
+        map.add_variable('INTEGER16 value')  # 0x2001
+        map.add_variable('UNSIGNED8 value', length=4)  # 0x2002
         map.add_variable('INTEGER8 value', length=4)  # 0x2003
-        map.add_variable('INTEGER32 value')           # 0x2004
+        map.add_variable('INTEGER32 value')  # 0x2004
 
         # Write some values
         map['INTEGER16 value'].raw = -3
@@ -30,14 +30,12 @@ class TestPDO(unittest.TestCase):
         self.assertEqual(map['INTEGER8 value'].raw, -2)
         self.assertEqual(map['INTEGER32 value'].raw, 0x01020304)
 
-        
         self.assertEqual(node.tpdo[1]['INTEGER16 value'].raw, -3)
         self.assertEqual(node.tpdo[1]['UNSIGNED8 value'].raw, 0xf)
         self.assertEqual(node.tpdo[1]['INTEGER8 value'].raw, -2)
         self.assertEqual(node.tpdo[1]['INTEGER32 value'].raw, 0x01020304)
         self.assertEqual(node.tpdo['INTEGER32 value'].raw, 0x01020304)
-        
-        
+
         # Test diferent types of access
         self.assertEqual(node.pdo[0x1600]['INTEGER16 value'].raw, -3)
         self.assertEqual(node.pdo['INTEGER16 value'].raw, -3)
@@ -45,10 +43,9 @@ class TestPDO(unittest.TestCase):
         self.assertEqual(node.pdo[0x2001].raw, -3)
         self.assertEqual(node.tpdo[0x2001].raw, -3)
         self.assertEqual(node.pdo[0x2002].raw, 0xf)
+        self.assertEqual(node.pdo['0x2002'].raw, 0xf)
         self.assertEqual(node.tpdo[0x2002].raw, 0xf)
         self.assertEqual(node.pdo[0x1600][0x2002].raw, 0xf)
-    
-        
 
 
 if __name__ == "__main__":

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -10,10 +10,10 @@ class TestPDO(unittest.TestCase):
     def test_bit_mapping(self):
         node = canopen.Node(1, EDS_PATH)
         map = node.pdo.tx[1]
-        map.add_variable('INTEGER16 value')
-        map.add_variable('UNSIGNED8 value', length=4)
-        map.add_variable('INTEGER8 value', length=4)
-        map.add_variable('INTEGER32 value')
+        map.add_variable('INTEGER16 value')           # 0x2001
+        map.add_variable('UNSIGNED8 value', length=4) # 0x2002
+        map.add_variable('INTEGER8 value', length=4)  # 0x2003
+        map.add_variable('INTEGER32 value')           # 0x2004
 
         # Write some values
         map['INTEGER16 value'].raw = -3
@@ -42,6 +42,12 @@ class TestPDO(unittest.TestCase):
         self.assertEqual(node.pdo[0x1600]['INTEGER16 value'].raw, -3)
         self.assertEqual(node.pdo['INTEGER16 value'].raw, -3)
         self.assertEqual(node.pdo.tx[1]['INTEGER16 value'].raw, -3)
+        self.assertEqual(node.pdo[0x2001].raw, -3)
+        self.assertEqual(node.tpdo[0x2001].raw, -3)
+        self.assertEqual(node.pdo[0x2002].raw, 0xf)
+        self.assertEqual(node.tpdo[0x2002].raw, 0xf)
+        self.assertEqual(node.pdo[0x1600][0x2002].raw, 0xf)
+    
         
 
 


### PR DESCRIPTION
Now the mapped objects in the PDO can be access by three ways e.g.:
node.tpdo['Statusword']
node.tpdo['0x6041']
node.tpdo[0x6041]
