### PR TITLE
fix issue in the load_configuration() preventing one to set objects that were not records or arrays

### DIFF
--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -89,27 +89,46 @@ class RemoteNode(BaseNode):
         """
         self.sdo.download(0x1011, subindex, b"load")
 
+    def __load_configuration_helper(self, index, subindex, name, value):
+        """Helper function to send SDOs to the remote node
+        :param index: Object index
+        :param subindex: Object sub-index (if it does not exist e should be None)
+        :param name: Object name
+        :param value: Value to set in the object
+        """
+        try:
+            if subindex is not None:
+                logger.info(str('SDO [{index}][{subindex}]: {name}: {value}'.format(
+                    index=format(index, '#04x'),
+                    subindex=subindex,
+                    name=name,
+                    value=format(value, '#04x'))))
+                self.sdo[index][subindex].raw = value
+            else:
+                self.sdo[index].raw = value
+                logger.info(str('SDO [{index}]: {name}: {value}'.format(
+                    index=format(index, '#04x'),
+                    name=name,
+                    value=format(value, '#04x'))))
+        except canopen.SdoCommunicationError as e:
+            logger.info(str(e))
+        except canopen.SdoAbortedError as e:
+            # WORKAROUND for broken implementations: the SDO is set but the error
+            # "Attempt to write a read-only object" is raised any way.
+            if e.code != 0x06010002:
+                # Abort codes other than "Attempt to write a read-only object"
+                # should still be reported.
+                logger.warning('[ERROR SETTING object {0}:{1}]  {2}'.format(index, subindex, str(e)))
+                logger.info(str(e))
+                raise
+
     def load_configuration(self):
         ''' Load the configuration of the node from the object dictionary.'''
         for obj in self.object_dictionary.values():
             if isinstance(obj, Record) or isinstance(obj, Array):
                 for subobj in obj.values():
-                    if isinstance(subobj, Variable) and (subobj.access_type == 'rw') and (subobj.value is not None) :
-                        logger.debug(str('SDO [{index}][{subindex}]: {name}: {value}'.format(
-                            index=subobj.index,
-                            subindex=subobj.subindex,
-                            name=subobj.name,
-                            value=subobj.value)))
-                        try:
-                            self.sdo[subobj.index][subobj.subindex].raw = subobj.value
-                        except canopen.SdoCommunicationError as e:
-                            logger.info(str(e))
-                        except canopen.SdoAbortedError as e:
-                            # WORKAROUND for broken implementations: the SDO is set but the error
-                            # "Attempt to write a read-only object" is raised any way.
-                            if e.code != 0x06010002:
-                                # Abort codes other than "Attempt to write a read-only object"
-                                # should still be reported.
-                                print('[ERROR SETTING object {0}:{1}]  {2}'.format(subobj.index, subobj.subindex, str(e)))
-                                logger.info(str(e))
-                                raise
+                    if isinstance(subobj, Variable) and (subobj.access_type == 'rw') and (subobj.value is not None):
+                        self.__load_configuration_helper(subobj.index, subobj.subindex, subobj.name, subobj.value)
+            elif isinstance(obj, Variable) and (obj.access_type == 'rw') and (obj.value is not None):
+                self.__load_configuration_helper(obj.index, None, obj.name, obj.value)
+

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -127,8 +127,8 @@ class RemoteNode(BaseNode):
         for obj in self.object_dictionary.values():
             if isinstance(obj, Record) or isinstance(obj, Array):
                 for subobj in obj.values():
-                    if isinstance(subobj, Variable) and (subobj.access_type == 'rw') and (subobj.value is not None):
+                    if isinstance(subobj, Variable) and (subobj.access_type in ('rw', 'rww')) and (subobj.value is not None):
                         self.__load_configuration_helper(subobj.index, subobj.subindex, subobj.name, subobj.value)
-            elif isinstance(obj, Variable) and (obj.access_type == 'rw') and (obj.value is not None):
+            elif isinstance(obj, Variable) and (obj.access_type in ('rw', 'rww')) and (obj.value is not None):
                 self.__load_configuration_helper(obj.index, None, obj.name, obj.value)
 


### PR DESCRIPTION
The previous implementation only allow one to set composed objects, this is objects with sub-index's. Now we can set all the supported objects loaded by the EDS file