### PR TITLE
Small enhancement to the EDS parser + bug fix of a failing unites

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -69,7 +69,7 @@ def import_eds(source, node_id):
             continue
 
         # Match subindexes
-        match = re.match(r"^([0-9A-Fa-f]{4})sub([0-9A-Fa-f]+)$", section)
+        match = re.match(r"^([0-9A-Fa-f]{4})[S|s]ub([0-9A-Fa-f]+)$", section)
         if match is not None:
             index = int(match.group(1), 16)
             subindex = int(match.group(2), 16)

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -862,3 +862,16 @@ DataType=0x0008
 AccessType=rw
 DefaultValue=
 PDOMapping=0
+
+[3010]
+ParameterName=ReadRawValue
+ObjectType=0x9
+SubNumber=1
+
+[3010Sub0]
+ParameterName=Temperature
+ObjectType=0x7
+DataType=0x0008
+AccessType=ro
+DefaultValue=0
+PDOMapping=1

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -72,3 +72,7 @@ class TestEDS(unittest.TestCase):
     def test_compact_subobj_parameter_name_with_percent(self):
         name = self.od[0x3006].name
         self.assertEqual(name, 'Valve 1 % Open')
+
+    def test_sub_index_w_capital_s(self):
+        name = self.od[0x3010][0].name
+        self.assertEqual(name, 'Temperature')

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -84,7 +84,7 @@ class TestSDO(unittest.TestCase):
         self.local_node.nmt.stop_heartbeat()
         # The NMT master will change the state INITIALISING (0)
         # to PRE-OPERATIONAL (127)
-        self.assertEqual(state, canopen.nmt.NMT_STATES[127])
+        self.assertEqual(state, 'PRE-OPERATIONAL')
 
     def test_nmt_state_initializing_to_preoper(self):
         # Initialize the heartbeat timer
@@ -220,6 +220,7 @@ class TestNMT(unittest.TestCase):
         time.sleep(0.2)
         self.assertEqual(self.remote_node.nmt.state, 'OPERATIONAL')
 
+        self.local_node.nmt.stop_heartbeat()
 
 class TestPDO(unittest.TestCase):
     """


### PR DESCRIPTION
Hi, Christian

I have made a small enhancement of the EDS parser so that it handles EDS files where the subindex is written as [<index>]Sub<sub-index>, since I did come across this in a EDS file.

Also I have fixed a small error in a unites, that occasionally failed.

Regards

Fredrik