### PR TITLE
Prevent crash in `SyncProducer.stop()` if `Network.sync.start()` was not called.

### DIFF
--- a/canopen/sync.py
+++ b/canopen/sync.py
@@ -36,4 +36,5 @@ class SyncProducer(object):
 
     def stop(self):
         """Stop periodic transmission of SYNC message."""
-        self._task.stop()
+        if self._task is not None:
+            self._task.stop()


### PR DESCRIPTION
If we call `Network.sync.stop()` before calling `Network.sync.start()` then `_task` is not defined. Int his case `stop()` should be a no-op.