### PR TITLE
Added on_command method in NmtSlave which calls update_heartbeat 

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -197,6 +197,10 @@ class NmtSlave(NmtBase):
         self._heartbeat_time_ms = 0
         self._local_node = local_node
 
+    def on_command(self, can_id, data, timestamp):
+        super(NmtSlave, self).on_command(can_id, data, timestamp)
+        self.update_heartbeat()
+
     def send_command(self, code):
         """Send an NMT command code to the node.
 


### PR DESCRIPTION
This is to properly reflect NmtSlave state when receiving commands from NMT Master.

I was testing the LocalNode functionality and couldn't figure out why, when sending command to to slave to go to operation from NMT Master, the slave state was not correctly picked up on the Master side.

I believe this pull request could be the solution, but I might have misunderstood how this is supposed to work.