### PR TITLE
Fix SDO communication error printout

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -406,7 +406,8 @@ class WritableStream(io.RawIOBase):
             res_command, = struct.unpack("B", response[0:1])
             if res_command & 0xE0 != RESPONSE_SEGMENT_DOWNLOAD:
                 raise SdoCommunicationError(
-                    "Unexpected response 0x%02X (expected 0x%02X)" % res_command)
+                    "Unexpected response 0x%02X (expected 0x%02X)" %
+                    (res_command, RESPONSE_SEGMENT_DOWNLOAD))
         # Advance position
         self.pos += bytes_sent
         return bytes_sent


### PR DESCRIPTION
Before this change, raising an exception would fail with
TypeError: not enough arguments for format string