### PR TITLE
Allow for timestamps of other types than float

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -174,7 +174,7 @@ class Map(object):
         #: Current message data
         self.data = bytearray()
         #: Timestamp of last received message
-        self.timestamp = 0
+        self.timestamp = None
         #: Period of receive message transmission in seconds
         self.period = None
         self.callbacks = []
@@ -268,7 +268,7 @@ class Map(object):
             with self.receive_condition:
                 self.is_received = True
                 self.data = data
-                self.period = timestamp - self.timestamp
+                self.period = timestamp - self.timestamp if self.timestamp is not None else timestamp
                 self.timestamp = timestamp
                 self.receive_condition.notify_all()
                 for callback in self.callbacks:

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -268,7 +268,8 @@ class Map(object):
             with self.receive_condition:
                 self.is_received = True
                 self.data = data
-                self.period = timestamp - self.timestamp if self.timestamp is not None else timestamp
+                if self.timestamp is not None:
+                    self.period = timestamp - self.timestamp
                 self.timestamp = timestamp
                 self.receive_condition.notify_all()
                 for callback in self.callbacks:


### PR DESCRIPTION
In stead of assigning 0 directly to a timestamp member in `canopen.pdo.Map`, set it to None in the constructor, then check whether it exists before doing the subtraction in `on_message`. This way, we can potentially use other types for the timestamp, *as long as subtracting two of them results in a float (meaning seconds)*.