### PR TITLE
EDS : Add loading of DummyUsage definitions

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -37,11 +37,11 @@ def import_eds(source, node_id):
 
     for section in eds.sections():
         # Match dummy definitions
-        match = re.match(r"^[D|d]ummy[U|u]sage$", section)
+        match = re.match(r"^[Dd]ummy[Uu]sage$", section)
         if match is not None:
-            for i in range(1,8):
+            for i in range(1, 8):
                 key = "Dummy%04d" % i
-                if eds.getint(section,key) == 1:
+                if eds.getint(section, key) == 1:
                     var = objectdictionary.Variable(key, i, 0)
                     var.data_type = i
                     var.access_type = "const"

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -36,6 +36,17 @@ def import_eds(source, node_id):
         od.node_id = int(eds.get("DeviceComissioning", "NodeID"))
 
     for section in eds.sections():
+        # Match dummy definitions
+        match = re.match(r"^[D|d]ummy[U|u]sage$", section)
+        if match is not None:
+            for i in range(1,8):
+                key = "Dummy%04d" % i
+                if eds.getint(section,key) == 1:
+                    var = objectdictionary.Variable(key, i, 0)
+                    var.data_type = i
+                    var.access_type = "const"
+                    od.add_object(var)
+
         # Match indexes
         match = re.match(r"^[0-9A-Fa-f]{4}$", section)
         if match is not None:

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -39,7 +39,7 @@ LSS_SerialNumber=0
 [DummyUsage]
 Dummy0001=0
 Dummy0002=0
-Dummy0003=0
+Dummy0003=1
 Dummy0004=0
 Dummy0005=0
 Dummy0006=0

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -76,3 +76,17 @@ class TestEDS(unittest.TestCase):
     def test_sub_index_w_capital_s(self):
         name = self.od[0x3010][0].name
         self.assertEqual(name, 'Temperature')
+
+    def test_dummy_variable(self):
+        var = self.od['Dummy0003']
+        self.assertIsInstance(var, canopen.objectdictionary.Variable)
+        self.assertEqual(var.index, 0x0003)
+        self.assertEqual(var.subindex, 0)
+        self.assertEqual(var.name, 'Dummy0003')
+        self.assertEqual(var.data_type, canopen.objectdictionary.INTEGER16)
+        self.assertEqual(var.access_type, 'const')
+        self.assertEqual(len(var), 16)
+
+    def test_dummy_variable_undefined(self):
+        with self.assertRaises(KeyError):
+            var_undef = self.od['Dummy0001']


### PR DESCRIPTION
In EDS parsing, add load of [DummyUsage] section in order to allow PDO Dummy Mapping as defined in §4.6.2 - "Mapping of dummy entries" of CiA 306 (v1.3)