### PR TITLE
Fix parsing of $NODEID to handle case differences and spaces.

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -137,6 +137,7 @@ def _convert_variable(node_id, var_type, value):
         return float(value)
     else:
         # COB-ID can have a suffix of '$NODEID+' so replace this with node_id before converting
+        value = value.replace(" ","").upper()
         if '$NODEID+' in value and node_id is not None:
             return int(value.replace('$NODEID+', ''), 0) + node_id
         else:


### PR DESCRIPTION
In some EDSs the values are written as $NodeID + 0x200 - see, for example:
[AHM36_A_CO.zip](https://github.com/christiansandberg/canopen/files/4352502/AHM36_A_CO.zip)

This PR fixes the parsing of such values.