### PR TITLE
Fix missing `self.` for checking state change in p402.py

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -439,7 +439,7 @@ class BaseNode402(RemoteNode):
         timeout = time.time() + 0.8 # 800 ms
         while self.state != target_state:
             next_state = self._next_state(target_state)
-            if _change_state(next_state):
+            if self._change_state(next_state):
                 continue       
             if time.time() > timeout:
                 raise RuntimeError('Timeout when trying to change state')


### PR DESCRIPTION
This should be fairly obvious. When changing state for a CiA402 node, there is currently an exception being raised due to the fact that the `_change_state` method is referenced without `self.`