### PR TITLE
Network disc: avoid to raise an error if 'bus' or 'notifier' is None

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -119,8 +119,10 @@ class Network(MutableMapping):
         for node in self.nodes.values():
             if hasattr(node, "pdo"):
                 node.pdo.stop()
-        self.notifier.stop()
-        self.bus.shutdown()
+        if self.notifier is not None:
+            self.notifier.stop()
+        if self.bus is not None:
+            self.bus.shutdown()
         self.bus = None
         self.check()
 


### PR DESCRIPTION
If 'bus' is not connected yet and for other reasons an exception is raised and some 'finally' block contains a call to disconnect() an error is raised.