### PR TITLE
Reading DefaultValue from EDS is wrong for data type OCTET_STRING and DOMAIN.

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -138,7 +138,9 @@ def import_from_node(node_id, network):
 
 
 def _convert_variable(node_id, var_type, value):
-    if var_type in objectdictionary.DATA_TYPES:
+    if var_type in (objectdictionary.OCTET_STRING, objectdictionary.DOMAIN):
+        return bytes.fromhex(value)
+    elif var_type in (objectdictionary.VISIBLE_STRING, objectdictionary.UNICODE_STRING):
         return value
     elif var_type in objectdictionary.FLOAT_TYPES:
         return float(value)


### PR DESCRIPTION
The DefaultValue for data type OCTET_STRING and DOMAIN is formatted with two
hex digits for each byte in the EDS - see corresponding CiA standard. Also
the content of the default value has to end up in a bytes instance and not in
a string instance. (otherwise an exception is thrown when the SDOServer tries
to answer a SDO upload request for an object dictionary entry with this data type.)