### PR TITLE
Respect rtr_allowed in Pdo.Map.Save()

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -338,7 +338,7 @@ class Map(object):
         """Save PDO configuration for this map using SDO."""
         logger.info("Setting COB-ID 0x%X and temporarily disabling PDO",
                     self.cob_id)
-        self.com_record[1].raw = self.cob_id | PDO_NOT_VALID
+        self.com_record[1].raw = self.cob_id | PDO_NOT_VALID | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0)
         if self.trans_type is not None:
             logger.info("Setting transmission type to %d", self.trans_type)
             self.com_record[2].raw = self.trans_type
@@ -388,7 +388,8 @@ class Map(object):
 
         if self.enabled:
             logger.info("Enabling PDO")
-            self.com_record[1].raw = self.cob_id
+            self.com_record[1].raw = self.cob_id | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0)
+
             self.pdo_node.network.subscribe(self.cob_id, self.on_message)
 
     def clear(self):


### PR DESCRIPTION
Hello, I was playing around with a Roboteq FBL2360T motor controller and trying to map PDOs with the library always ended up  to an exception: `SdoAbortedError: Code 0x06090030, Value range of parameter exceeded`

The problem is that `node.tpdo[1].save()` will try to right to `0x180001` a value that is not acceptable. The field has originally the 30th bit set and trying to disable the PDO by setting the 31th bit will fail unless bit 30 is also set. The device probably does not support remote frames.

The standard states[1]:

> Bit 30 is used to indicate if CAN remote frames are allowed or not. This is not supported by all CAN implementations. In some, the remote frame transmission can't be disabled.

This is what this PL addresses.

P.S: I've also noticed that the field there is treated as a can-id. This is not always the case:

> The COB-ID is not the CAN-ID!
> The COB-ID sub-parameter in the CANopen dictionary is a 32-bit value. It contains some control bits, e.g. bit 29 indicating how to interpret following bits. In case bit 29 is 0, the following 18 bits are ignored and the remaining 11 bits are regarded as the CAN-ID to be used for the PDO. It is transmitted using the CAN base frame format. If the bit is 1, the following bits are interpreted as a 29-bit ID. This means the corresponding PDO is transmitted in the CAN extended frame format.

Maybe it's better if you assert on the 29th bit to fail early or add support for the 29-bit ID.

[1] https://www.can-cia.org/can-knowledge/canopen/pdo-protocol/