### PR TITLE
Shutdown an already running periodic PDO before starting a new one

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -441,6 +441,10 @@ class Map(object):
 
         :param float period: Transmission period in seconds
         """
+        # Stop an already running transmission if we have one, otherwise we
+        # overwrite the reference and can lose our handle to shut it down
+        self.stop()
+
         if period is not None:
             self.period = period
 


### PR DESCRIPTION
I've noticed that you can call start on the PDOs multiple times at which point you can no longer shut down the periodic sends, except for the most recent. I believe the expected behavior of calling start multiple times would be to shutdown the existing periodic send and start a new one at the new rate. The way it is handled currently seems unintentional, as the existing reference is blindly overwritten and then you lose the handle to shut it down.