### PR TITLE
added SDO Abort if a timeout occurs when sending a SDO request

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -86,6 +86,7 @@ class SdoClient(SdoBase):
             except SdoCommunicationError as e:
                 retries_left -= 1
                 if not retries_left:
+                    self.abort(0x5040000) 
                     raise
                 logger.warning(str(e))
 


### PR DESCRIPTION
If during a SDO Request (e.g. block transfer) a timeout occurs, the SDO request will stop but the SDO Server will still be in the receiving state until an SDO Abort is sent. With this fix an SDO Abort is sent when a timeout occurs and with this the SDO Server state machine will be reset. 