### PR TITLE
added argument for block transfer to enable/disable CRC Support

### DIFF
--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -112,7 +112,7 @@ class Variable(variable.Variable):
         self.sdo_node.download(self.od.index, self.od.subindex, data, force_segment)
 
     def open(self, mode="rb", encoding="ascii", buffering=1024, size=None,
-             block_transfer=False):
+             block_transfer=False, request_crc_support=True):
         """Open the data stream as a file like object.
 
         :param str mode:
@@ -141,4 +141,4 @@ class Variable(variable.Variable):
             A file like object.
         """
         return self.sdo_node.open(self.od.index, self.od.subindex, mode,
-                                  encoding, buffering, size, block_transfer)
+                                  encoding, buffering, size, block_transfer, request_crc_support=request_crc_support)

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -136,6 +136,8 @@ class Variable(variable.Variable):
             Size of data to that will be transmitted.
         :param bool block_transfer:
             If block transfer should be used.
+        :param bool request_crc_support:
+            If crc calculation should be requested when using block transfer
 
         :returns:
             A file like object.

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -155,7 +155,7 @@ class SdoClient(SdoBase):
         fp.close()
 
     def open(self, index, subindex=0, mode="rb", encoding="ascii",
-             buffering=1024, size=None, block_transfer=False, force_segment=False):
+             buffering=1024, size=None, block_transfer=False, force_segment=False, request_crc_support=True):
         """Open the data stream as a file like object.
 
         :param int index:
@@ -192,7 +192,7 @@ class SdoClient(SdoBase):
         buffer_size = buffering if buffering > 1 else io.DEFAULT_BUFFER_SIZE
         if "r" in mode:
             if block_transfer:
-                raw_stream = BlockUploadStream(self, index, subindex)
+                raw_stream = BlockUploadStream(self, index, subindex, request_crc_support=request_crc_support)
             else:
                 raw_stream = ReadableStream(self, index, subindex)
             if buffering:
@@ -201,7 +201,7 @@ class SdoClient(SdoBase):
                 return raw_stream
         if "w" in mode:
             if block_transfer:
-                raw_stream = BlockDownloadStream(self, index, subindex, size)
+                raw_stream = BlockDownloadStream(self, index, subindex, size, request_crc_support=request_crc_support)
             else:
                 raw_stream = WritableStream(self, index, subindex, size, force_segment)
             if buffering:
@@ -446,7 +446,7 @@ class BlockUploadStream(io.RawIOBase):
 
     crc_supported = False
 
-    def __init__(self, sdo_client, index, subindex=0):
+    def __init__(self, sdo_client, index, subindex=0, request_crc_support=True):
         """
         :param canopen.sdo.SdoClient sdo_client:
             The SDO client to use for reading.
@@ -466,7 +466,9 @@ class BlockUploadStream(io.RawIOBase):
                      sdo_client.rx_cobid - 0x600)
         # Initiate Block Upload
         request = bytearray(8)
-        command = REQUEST_BLOCK_UPLOAD | INITIATE_BLOCK_TRANSFER | CRC_SUPPORTED
+        command = REQUEST_BLOCK_UPLOAD | INITIATE_BLOCK_TRANSFER
+        if request_crc_support:
+            command |= CRC_SUPPORTED
         struct.pack_into("<BHBBB", request, 0,
                          command, index, subindex, self.blksize, 0)
         response = sdo_client.request_response(request)
@@ -596,7 +598,7 @@ class BlockUploadStream(io.RawIOBase):
 class BlockDownloadStream(io.RawIOBase):
     """File like object for block download."""
 
-    def __init__(self, sdo_client, index, subindex=0, size=None):
+    def __init__(self, sdo_client, index, subindex=0, size=None, request_crc_support=True):
         """
         :param canopen.sdo.SdoClient sdo_client:
             The SDO client to use for communication.
@@ -614,7 +616,9 @@ class BlockDownloadStream(io.RawIOBase):
         self._seqno = 0
         self._crc = sdo_client.crc_cls()
         self._last_bytes_sent = 0
-        command = REQUEST_BLOCK_DOWNLOAD | INITIATE_BLOCK_TRANSFER | CRC_SUPPORTED
+        command = REQUEST_BLOCK_DOWNLOAD | INITIATE_BLOCK_TRANSFER
+        if request_crc_support:
+            command |= CRC_SUPPORTED
         request = bytearray(8)
         logger.info("Initiating block download for 0x%X:%d", index, subindex)
         if size is not None:

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -185,7 +185,9 @@ class SdoClient(SdoBase):
             If block transfer should be used.
         :param bool force_segment:
             Force use of segmented download regardless of data size.
-
+        :param bool request_crc_support:
+            If crc calculation should be requested when using block transfer
+        
         :returns:
             A file like object.
         """
@@ -454,6 +456,8 @@ class BlockUploadStream(io.RawIOBase):
             Object dictionary index to read from.
         :param int subindex:
             Object dictionary sub-index to read from.
+        :param bool request_crc_support:
+            If crc calculation should be requested when using block transfer            
         """
         self._done = False
         self.sdo_client = sdo_client
@@ -608,6 +612,8 @@ class BlockDownloadStream(io.RawIOBase):
             Object dictionary sub-index to read from.
         :param int size:
             Size of data in number of bytes if known in advance.
+        :param bool request_crc_support:
+            If crc calculation should be requested when using block transfer            
         """
         self.sdo_client = sdo_client
         self.size = size


### PR DESCRIPTION
We had some problems with domain transfers when the SDO Server does not support the CRC_SUPPORTED Flag for the Block Transfer. With this you can disable (optional) the CRC_SUPPORTED Flag when calling open(). 