### PR TITLE
DS402: Cache supported operation modes

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -369,8 +369,11 @@ class BaseNode402(RemoteNode):
         :return: If the operation mode is supported
         :rtype: bool
         """
-        mode_support = self.sdo[0x6502].raw & OperationMode.SUPPORTED[mode]
-        return mode_support == OperationMode.SUPPORTED[mode]
+        if not hasattr(self, '_op_mode_support'):
+            # Cache value only on first lookup, this object should never change.
+            self._op_mode_support = self.sdo[0x6502].raw
+        bits = OperationMode.SUPPORTED[mode]
+        return self._op_mode_support & bits == bits
 
     def on_TPDOs_update_callback(self, mapobject):
         """This function receives a map object.

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -372,6 +372,8 @@ class BaseNode402(RemoteNode):
         if not hasattr(self, '_op_mode_support'):
             # Cache value only on first lookup, this object should never change.
             self._op_mode_support = self.sdo[0x6502].raw
+            logger.info('Caching node {n} supported operation modes 0x{m:04X}'.format(
+                n=self.id, m=self._op_mode_support))
         bits = OperationMode.SUPPORTED[mode]
         return self._op_mode_support & bits == bits
 


### PR DESCRIPTION
Requesting the same immutable OD object on each change of operation mode takes quite some time to process.  Introduce a local cache member variable in order to avoid requesting more than once.