### PR TITLE
DS402: Skip explicit change to SWITCHED ON state.

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -298,7 +298,6 @@ class BaseNode402(RemoteNode):
         :rtype: bool
         """
         previus_op_mode = self.op_mode
-        self.state = 'SWITCHED ON'
         self.op_mode = 'HOMING'
         # The homing process will initialize at operation enabled
         self.state = 'OPERATION ENABLED'


### PR DESCRIPTION
The `BaseNode402.homing()` method tries to enter state SWITCHED ON upon entry.  That's unnecessary, the application should handle these transitions.  But more importantly, it actually fails in many cases, namely if the previous state is SWITCH ON DISABLED, the default power-up state of most devices.  There is an automatic way to reach OPERATION ENABLED over multiple intermediate steps, but the library does not know how to reach SWITCHED ON from any other state than OPERATION ENABLED or READY TO SWITCH ON.

In addition, setting the `op_mode` property will already change to SWITCHED ON only if coming from OPERATION ENABLED (which is usually a good idea to avoid unexpected movement).

Note that switching the operation mode to HOMING is actually safe in any power state.