### PR TITLE
DS402: Minimize side-effects of operation mode switching (ref #244)

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -370,15 +370,8 @@ class BaseNode402(RemoteNode):
             if not self.is_op_mode_supported(mode):
                 raise TypeError(
                     'Operation mode {0} not suppported on node {1}.'.format(mode, self.id))
-
-            start_state = self.state
-
-            if self.state == 'OPERATION ENABLED':
-                self.state = 'SWITCHED ON'
-
             # operation mode
             self.sdo[0x6060].raw = OperationMode.NAME2CODE[mode]
-
             timeout = time.monotonic() + self.TIMEOUT_SWITCH_OP_MODE
             while self.op_mode != mode:
                 if time.monotonic() > timeout:
@@ -390,7 +383,6 @@ class BaseNode402(RemoteNode):
         except (RuntimeError, ValueError) as e:
             logger.warning('{0}'.format(str(e)))
         finally:
-            self.state = start_state # why?
             logger.info('Set node {n} operation mode to {m}.'.format(n=self.id, m=mode))
 
     def _clear_target_values(self):

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -375,9 +375,7 @@ class BaseNode402(RemoteNode):
 
             if self.state == 'OPERATION ENABLED':
                 self.state = 'SWITCHED ON'
-                # ensure the node does not move with an old value
-                self._clear_target_values() # Shouldn't this happen before it's switched on?
-                
+
             # operation mode
             self.sdo[0x6060].raw = OperationMode.NAME2CODE[mode]
 

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -369,7 +369,7 @@ class BaseNode402(RemoteNode):
         try:
             if not self.is_op_mode_supported(mode):
                 raise TypeError(
-                    'Operation mode {0} not suppported on node {1}.'.format(mode, self.id))
+                    'Operation mode {m} not suppported on node {n}.'.format(n=self.id, m=mode))
             # operation mode
             self.sdo[0x6060].raw = OperationMode.NAME2CODE[mode]
             timeout = time.monotonic() + self.TIMEOUT_SWITCH_OP_MODE
@@ -378,12 +378,11 @@ class BaseNode402(RemoteNode):
                     raise RuntimeError(
                         "Timeout setting node {0}'s new mode of operation to {1}.".format(
                             self.id, mode))
+            logger.info('Set node {n} operation mode to {m}.'.format(n=self.id, m=mode))
         except SdoCommunicationError as e:
             logger.warning('[SDO communication error] Cause: {0}'.format(str(e)))
         except (RuntimeError, ValueError) as e:
             logger.warning('{0}'.format(str(e)))
-        finally:
-            logger.info('Set node {n} operation mode to {m}.'.format(n=self.id, m=mode))
 
     def _clear_target_values(self):
         # [target velocity, target position, target torque]


### PR DESCRIPTION
The `BaseNode402.op_mode` setter carries out some precautionary steps as a side-effect.  Some of these were already questioned in the code comments.

These changes push the responsibility for these measures toward the application, where they are just as easy to implement, but it's hard to avoid them when not needed or harmful to the application logic.  The greatest possible benefit is less SDO bus traffic and delays when using the library functions, which sums up quickly with multiple drive controllers involved.