### PR TITLE
DS402: Allow handling the operation mode via PDO.

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -186,7 +186,8 @@ class Map(object):
         self.data = bytearray()
         #: Timestamp of last received message
         self.timestamp = None
-        #: Period of receive message transmission in seconds
+        #: Period of receive message transmission in seconds.
+        #: Set explicitly or using the :meth:`start()` method.
         self.period = None
         self.callbacks = []
         self.receive_condition = threading.Condition()
@@ -459,7 +460,10 @@ class Map(object):
     def start(self, period=None):
         """Start periodic transmission of message in a background thread.
 
-        :param float period: Transmission period in seconds
+        :param float period:
+            Transmission period in seconds.  Can be omitted if :attr:`period` has been set
+            on the object before.
+        :raises ValueError: When neither the argument nor the :attr:`period` is given.
         """
         # Stop an already running transmission if we have one, otherwise we
         # overwrite the reference and can lose our handle to shut it down

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -274,6 +274,23 @@ class Map(object):
         node_id = self.cob_id & 0x7F
         return "%sPDO%d_node%d" % (direction, map_id, node_id)
 
+    @property
+    def is_periodic(self):
+        """Indicate whether PDO updates will be transferred regularly.
+
+        If some external mechanism is used to transmit the PDO regularly, its cycle time
+        should be written to the :attr:`period` member for this property to work.
+        """
+        if self.period is not None:
+            # Configured from start() or externally
+            return True
+        elif self.trans_type is not None and self.trans_type <= 0xF0:
+            # TPDOs will be transmitted on SYNC, RPDOs need a SYNC to apply, so
+            # assume that the SYNC service is active.
+            return True
+        # Unknown transmission type, assume non-periodic
+        return False
+
     def on_message(self, can_id, data, timestamp):
         is_transmitting = self._task is not None
         if can_id == self.cob_id and not is_transmitting:

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -222,6 +222,7 @@ class BaseNode402(RemoteNode):
         self.setup_pdos()
         self._check_controlword_configured()
         self._check_statusword_configured()
+        self._check_op_mode_configured()
         self.nmt.state = 'OPERATIONAL'
         self.state = 'SWITCH ON DISABLED' # Why change state?
 
@@ -260,6 +261,16 @@ class BaseNode402(RemoteNode):
         if 0x6041 not in self.tpdo_values:  # Statusword
             raise ValueError(
                 "Statusword not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
+                    self.id))
+
+    def _check_op_mode_configured(self):
+        if 0x6060 not in self.rpdo_pointers:  # Operation Mode
+            logger.warning(
+                "Operation Mode not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
+                    self.id))
+        if 0x6061 not in self.tpdo_values:  # Operation Mode Display
+            logger.warning(
+                "Operation Mode Display not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
                     self.id))
 
     def reset_from_fault(self):

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -454,7 +454,9 @@ class BaseNode402(RemoteNode):
     def controlword(self, value):
         if 0x6040 in self.rpdo_pointers:
             self.rpdo_pointers[0x6040].raw = value
-            self.rpdo_pointers[0x6040].pdo_parent.transmit()
+            pdo = self.rpdo_pointers[0x6040].pdo_parent
+            if not pdo.is_periodic:
+                pdo.transmit()
         else:
             self.sdo[0x6040].raw = value
 

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -208,9 +208,9 @@ class BaseNode402(RemoteNode):
 
     def __init__(self, node_id, object_dictionary):
         super(BaseNode402, self).__init__(node_id, object_dictionary)
-        self.tpdo_values = dict()  # { index: TPDO_value }
+        self.tpdo_values = {}  # { index: value from last received TPDO }
         self.tpdo_pointers = {}  # { index: pdo.Map instance }
-        self.rpdo_pointers = dict()  # { index: RPDO_pointer }
+        self.rpdo_pointers = {}  # { index: pdo.Map instance }
 
     def setup_402_state_machine(self):
         """Configure the state machine by searching for a TPDO that has the StatusWord mapped.


### PR DESCRIPTION
~~This PR is based on #256 to avoid conflicts, thus should be merged after it.  If needed I can rebase after merging #256.~~
EDIT: Rebased on top of master with #256 merged.

Switching operation modes for several drives simultaneously must be done via PDO.  The current mechanism used for the `BaseNode402.op_mode` property supports only SDO.  Now the PDO method is tried first, but falls back to the SDO method if the relevant objects (0x6060 / 0x6061) are not mapped to PDOs.  In order to make sure an up-to-date value is returned for the property, the getter blocks until the TPDO has been received once, with a default timeout of 0.2 seconds leading to a `RuntimeError`. 

On a side track, `pdo.Map` gains a new property `is_periodic` which reflects whether the `period` member has been set (usually from `start()`), or if a synchronous transmission type is configured.  The above mentioned blocking behavior of the `op_mode` getter is skipped if the TPDO is not deemed periodic, to prevent the timeout from firing.  Similarly, transmitting the RPDO immediately in the `op_mode` setter is skipped when deemed periodic.  Same goes for the `controlword` setter, assuming that the application is responsible to set up the periodic transmission.