### PR TITLE
Small change in NMT log message and FIXME comment for DS402.

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -68,8 +68,8 @@ class NmtBase(object):
         """
         if code in COMMAND_TO_STATE:
             new_state = COMMAND_TO_STATE[code]
-            logger.info("Changing NMT state from %s to %s",
-                        NMT_STATES[self._state], NMT_STATES[new_state])
+            logger.info("Changing NMT state on node %d from %s to %s",
+                        self.id, NMT_STATES[self._state], NMT_STATES[new_state])
             self._state = new_state
 
     @property

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -263,6 +263,8 @@ class BaseNode402(RemoteNode):
         if self.state == 'FAULT':
             # Resets the Fault Reset bit (rising edge 0 -> 1)
             self.controlword = State402.CW_DISABLE_VOLTAGE
+            # FIXME! The rising edge happens with the transitions toward OPERATION
+            # ENABLED below, but until then the loop will always reach the timeout!
             timeout = time.monotonic() + self.TIMEOUT_RESET_FAULT
             while self.is_faulted():
                 if time.monotonic() > timeout:


### PR DESCRIPTION
NMT state change messages should indicate for which node they're logged.

The `BaseNode402.reset_from_fault()` does not work as intended.  It doesn't actually make sure the fault is cleared when it returns, but just unconditionally sets the rising edge on the Fault Reset bit after the actual check times out.  This needs a rework, so at least add an explanation how the code works now and what should better happen.