### PR TITLE
DS402: Restore operation mode after homing only on explicit request.

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -295,13 +295,10 @@ class BaseNode402(RemoteNode):
             self.op_mode = previous_op_mode
         return homingstatus in ('TARGET REACHED', 'ATTAINED')
 
-    def homing(self, timeout=TIMEOUT_HOMING_DEFAULT, set_new_home=True):
+    def homing(self, timeout=TIMEOUT_HOMING_DEFAULT):
         """Execute the configured Homing method on the node.
 
         :param int timeout: Timeout value (default: 30).
-        :param bool set_new_home:
-            Defines if the node should set the home offset object (0x607C) to the current
-            position after the homing procedure (default: true).
         :return: If the homing was complete with success.
         :rtype: bool
         """
@@ -327,10 +324,6 @@ class BaseNode402(RemoteNode):
                 time.sleep(self.INTERVAL_CHECK_STATE)
                 if time.monotonic() > t:
                     raise RuntimeError('Unable to home, timeout reached')
-            if set_new_home:
-                actual_position = self.sdo[0x6063].raw
-                self.sdo[0x607C].raw = actual_position  # Home Offset
-                logger.info('Homing offset set to {0}'.format(actual_position))
             logger.info('Homing mode carried out successfully.')
             return True
         except RuntimeError as e:

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -295,14 +295,17 @@ class BaseNode402(RemoteNode):
             self.op_mode = previous_op_mode
         return homingstatus in ('TARGET REACHED', 'ATTAINED')
 
-    def homing(self, timeout=TIMEOUT_HOMING_DEFAULT):
+    def homing(self, timeout=TIMEOUT_HOMING_DEFAULT, restore_op_mode=False):
         """Execute the configured Homing method on the node.
 
         :param int timeout: Timeout value (default: 30).
+        :param bool restore_op_mode:
+            Switch back to the previous operation mode after homing (default: no).
         :return: If the homing was complete with success.
         :rtype: bool
         """
-        previus_op_mode = self.op_mode
+        if restore_op_mode:
+            previous_op_mode = self.op_mode
         self.state = 'SWITCHED ON'
         self.op_mode = 'HOMING'
         # The homing process will initialize at operation enabled
@@ -329,7 +332,8 @@ class BaseNode402(RemoteNode):
         except RuntimeError as e:
             logger.info(str(e))
         finally:
-            self.op_mode = previus_op_mode
+            if restore_op_mode:
+                self.op_mode = previous_op_mode
         return False
 
     @property


### PR DESCRIPTION
This PR is based on #250 to avoid conflicts, thus should be merged after it. If needed I can rebase after merging #250.

Add a new parameter `restore_op_mode` which defaults to `False`, and skip changing back to the previous mode unless it is explicitly enabled by passing True.  Note that most applications will decide on the needed mode after homing and therefore do not need this behavior, hence the new default.

As explained in #244.