### PR TITLE
DS402: Replace delay loops with waiting for TPDO reception.

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -202,6 +202,7 @@ class BaseNode402(RemoteNode):
     TIMEOUT_SWITCH_STATE_SINGLE = 0.4   # seconds
     INTERVAL_CHECK_STATE = 0.01         # seconds
     TIMEOUT_HOMING_DEFAULT = 30         # seconds
+    INTERVAL_CHECK_HOMING = 0.1         # seconds
 
     def __init__(self, node_id, object_dictionary):
         super(BaseNode402, self).__init__(node_id, object_dictionary)
@@ -307,6 +308,7 @@ class BaseNode402(RemoteNode):
         t = time.monotonic() + timeout
         try:
             while homingstatus not in ('TARGET REACHED', 'ATTAINED'):
+                time.sleep(self.INTERVAL_CHECK_HOMING)
                 for key, value in Homing.STATES.items():
                     # check if the Statusword after applying the bitmask
                     # corresponds with the needed bits to determine the current status
@@ -316,7 +318,6 @@ class BaseNode402(RemoteNode):
                 if homingstatus in ('INTERRUPTED', 'ERROR VELOCITY IS NOT ZERO',
                                     'ERROR VELOCITY IS ZERO'):
                     raise RuntimeError('Unable to home. Reason: {0}'.format(homingstatus))
-                time.sleep(self.INTERVAL_CHECK_STATE)
                 if time.monotonic() > t:
                     raise RuntimeError('Unable to home, timeout reached')
             if set_new_home:

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -281,6 +281,7 @@ class BaseNode402(RemoteNode):
         if previous_op_mode != 'HOMING':
             logger.info('Switch to HOMING from %s', previous_op_mode)
             self.op_mode = 'HOMING'
+        time.sleep(self.INTERVAL_CHECK_HOMING)
         homingstatus = None
         for key, value in Homing.STATES.items():
             bitmask, bits = value

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -275,18 +275,25 @@ class BaseNode402(RemoteNode):
         bitmask, bits = State402.SW_MASK['FAULT']
         return self.statusword & bitmask == bits
 
+    def _homing_status(self):
+        """Interpret the current Statusword bits as homing state string."""
+        # Wait to make sure an RPDO was received.  Should better check for reception
+        # instead of this hard-coded delay, but at least it can be configured per node.
+        time.sleep(self.INTERVAL_CHECK_HOMING)
+        status = None
+        for key, value in Homing.STATES.items():
+            bitmask, bits = value
+            if self.statusword & bitmask == bits:
+                status = key
+        return status
+
     def is_homed(self, restore_op_mode=False):
         """Switch to homing mode and determine its status."""
         previous_op_mode = self.op_mode
         if previous_op_mode != 'HOMING':
             logger.info('Switch to HOMING from %s', previous_op_mode)
             self.op_mode = 'HOMING'
-        time.sleep(self.INTERVAL_CHECK_HOMING)
-        homingstatus = None
-        for key, value in Homing.STATES.items():
-            bitmask, bits = value
-            if self.statusword & bitmask == bits:
-                homingstatus = key
+        homingstatus = self._homing_status()
         if restore_op_mode:
             self.op_mode = previous_op_mode
         return homingstatus in ('TARGET REACHED', 'ATTAINED')
@@ -309,13 +316,7 @@ class BaseNode402(RemoteNode):
         t = time.monotonic() + timeout
         try:
             while homingstatus not in ('TARGET REACHED', 'ATTAINED'):
-                time.sleep(self.INTERVAL_CHECK_HOMING)
-                for key, value in Homing.STATES.items():
-                    # check if the Statusword after applying the bitmask
-                    # corresponds with the needed bits to determine the current status
-                    bitmask, bits = value
-                    if self.statusword & bitmask == bits:
-                        homingstatus = key
+                homingstatus = self._homing_status()
                 if homingstatus in ('INTERRUPTED', 'ERROR VELOCITY IS NOT ZERO',
                                     'ERROR VELOCITY IS ZERO'):
                     raise RuntimeError('Unable to home. Reason: {0}'.format(homingstatus))

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -309,8 +309,10 @@ class BaseNode402(RemoteNode):
         self.op_mode = 'HOMING'
         # The homing process will initialize at operation enabled
         self.state = 'OPERATION ENABLED'
-        homingstatus = 'IN PROGRESS'
-        self.controlword = State402.CW_OPERATION_ENABLED | Homing.CW_START
+        homingstatus = 'UNKNOWN'
+        self.controlword = State402.CW_OPERATION_ENABLED | Homing.CW_START  # does not block
+        # Wait for one extra cycle, to make sure the controlword was received
+        self.check_statusword()
         t = time.monotonic() + timeout
         try:
             while homingstatus not in ('TARGET REACHED', 'ATTAINED'):


### PR DESCRIPTION
This PR is based on #252 to avoid conflicts, thus should be merged after it. If needed I can rebase after merging #252.

Several methods loop around waiting for some expected `statusword` value, usually calling `time.sleep()` with the `INTERVAL_CHECK_STATE` or `INTERVAL_CHECK_HOMING` constants.  Replace that with a call to a new method `check_statusword()`, which will only block until the TPDO is received.

This allows for possibly shorter delays, because the delay can be cut short when the TPDO arrives in between.  But rate limiting the checking loops is still achieved through the blocking behavior of check_statusword().

If no TPDO is configured, the statusword will fall back to checking via SDO, which will also result in periodic checks, but only rate limited by the SDO round-trip time.  Anyway this is not a recommended mode of operation, as the warning in `_check_statusword_configured()` points out.