### PR TITLE
DS402: Fix missing fallback behavior in check_statusword().

### DIFF
--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -477,9 +477,9 @@ class BaseNode402(RemoteNode):
             return self.sdo[0x6041].raw
 
     def check_statusword(self, timeout=None):
-        """Report an up-to-date reading of the statusword (0x6041) from the device.
+        """Report an up-to-date reading of the Statusword (0x6041) from the device.
 
-        If the TPDO with the statusword is configured as periodic, this method blocks
+        If the TPDO with the Statusword is configured as periodic, this method blocks
         until one was received.  Otherwise, it uses the SDO fallback of the ``statusword``
         property.
 
@@ -494,6 +494,8 @@ class BaseNode402(RemoteNode):
                 timestamp = pdo.wait_for_reception(timeout or self.TIMEOUT_CHECK_TPDO)
                 if timestamp is None:
                     raise RuntimeError('Timeout waiting for updated statusword')
+            else:
+                return self.sdo[0x6041].raw
         return self.statusword
 
     @property


### PR DESCRIPTION
The docstring for `BaseNode402.check_statusword()` promises it will fall back to SDO if the TPDO is not configured as periodic.  However, that actually only happens when there is no TPDO for the Statusword at all.  Fix that small detail, as the code using this function relies on getting an up-to-date value and on the implicit throttling caused by the SDO round-trip time.