### PR TITLE
eds: Fix exception in comment parsing with hexadecimal line count.

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -41,7 +41,7 @@ def import_eds(source, node_id):
         }
 
     if eds.has_section("Comments"):
-        linecount = eds.getint("Comments", "Lines")
+        linecount = int(eds.get("Comments", "Lines"), 0)
         od.comments = '\n'.join([
             eds.get("Comments", "Line%i" % line)
             for line in range(1, linecount+1)


### PR DESCRIPTION
This fixes a bug introduced in #254, which immediately broke parsing of my EDS files.

Inside an EDS file's [Comments] section, the Lines attribute may be expressed as a hexadecimal number prefixed with 0x.  The ConfigParser.getint() method however does not support such a format.

Switch to the default int() constructor with a base=0 argument to enable auto-detection of this condition.  The same is done for basically every other numeric value in the EDS importer.