### PR TITLE
Add 'relative' property for COB-ID vars relative to the node-ID

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -304,6 +304,8 @@ class Variable(object):
         self.max: Optional[int] = None
         #: Default value at start-up
         self.default: Optional[int] = None
+        #: Is the default value relative to the node-ID (only applies to COB-IDs)
+        self.relative = False
         #: The value of this variable stored in the object dictionary
         self.value: Optional[int] = None
         #: Data type according to the standard as an :class:`int`

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -262,6 +262,8 @@ def build_variable(eds, section, node_id, index, subindex=0):
     if eds.has_option(section, "DefaultValue"):
         try:
             var.default_raw = eds.get(section, "DefaultValue")
+            if '$NODEID' in var.default_raw:
+                var.relative = True
             var.default = _convert_variable(node_id, var.data_type, eds.get(section, "DefaultValue"))
         except ValueError:
             pass

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -26,6 +26,12 @@ class TestEDS(unittest.TestCase):
         self.assertEqual(var.data_type, canopen.objectdictionary.UNSIGNED16)
         self.assertEqual(var.access_type, 'rw')
         self.assertEqual(var.default, 0)
+        self.assertFalse(var.relative)
+
+    def test_relative_variable(self):
+        var = self.od['Receive PDO 0 Communication Parameter']['COB-ID use by RPDO 1']
+        self.assertTrue(var.relative)
+        self.assertEqual(var.default, 512 + self.od.node_id)
 
     def test_record(self):
         record = self.od['Identity object']


### PR DESCRIPTION
Add 'relative' property for COB-ID vars relative to the node-ID.

I have used the term "relative" only since I could not come up with something better (and CiA306-1 doesn't really help here). Other suggestions are most welcome.