### PR TITLE
Fix canmatrix export

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -114,7 +114,7 @@ class PdoBase(Mapping):
                     signal.addValues(value, desc)
                 frame.add_signal(signal)
             frame.calc_dlc()
-            db.frames.append(frame)
+            db.add_frame(frame)
         formats.dumpp({"": db}, filename)
         return db
 

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -88,8 +88,7 @@ class PdoBase(Mapping):
             if pdo_map.cob_id is None:
                 continue
             frame = canmatrix.Frame(pdo_map.name,
-                                    Id=pdo_map.cob_id,
-                                    extended=0)
+                                    arbitration_id=pdo_map.cob_id)
             for var in pdo_map.map:
                 is_signed = var.od.data_type in objectdictionary.SIGNED_TYPES
                 is_float = var.od.data_type in objectdictionary.FLOAT_TYPES
@@ -103,8 +102,8 @@ class PdoBase(Mapping):
                 name = name.replace(" ", "_")
                 name = name.replace(".", "_")
                 signal = canmatrix.Signal(name,
-                                          startBit=var.offset,
-                                          signalSize=var.length,
+                                          start_bit=var.offset,
+                                          size=var.length,
                                           is_signed=is_signed,
                                           is_float=is_float,
                                           factor=var.od.factor,
@@ -113,9 +112,9 @@ class PdoBase(Mapping):
                                           unit=var.od.unit)
                 for value, desc in var.od.value_descriptions.items():
                     signal.addValues(value, desc)
-                frame.addSignal(signal)
-            frame.calcDLC()
-            db.frames.addFrame(frame)
+                frame.add_signal(signal)
+            frame.calc_dlc()
+            db.frames.append(frame)
         formats.dumpp({"": db}, filename)
         return db
 


### PR DESCRIPTION
Exporting PDO mappings seems to be broken with canmatrix >= 0.9 (haven't checked exactly where it broke).
This PR should fix this.