### PR TITLE
Making sure the FileInfo section is preseved in EDS export

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -369,10 +369,10 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
             "EdsVersion": 4.2,
         }
 
-        file_info.setdefault("ModificationDate", defmtime.strftime("%m-%d-%Y"))
-        file_info.setdefault("ModificationTime", defmtime.strftime("%I:%m%p"))
-        for k, v in origFileInfo.items():
-            file_info.setdefault(k, v)
+    file_info.setdefault("ModificationDate", defmtime.strftime("%m-%d-%Y"))
+    file_info.setdefault("ModificationTime", defmtime.strftime("%I:%m%p"))
+    for k, v in origFileInfo.items():
+        file_info.setdefault(k, v)
 
     eds.add_section("FileInfo")
     for k, v in file_info.items():


### PR DESCRIPTION
The FileInfo read during an EDS import was lost when exporting to a new EDS because the code making the copy were only executed in case of a caught exception that should not occur in this scenario.