### PR TITLE
remove python-can >=v4.0.0 as dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,5 @@ classifier =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    python-can >= 3.0.0
+    python-can >= 3.0.0, <4.0.0
 include_package_data = True


### PR DESCRIPTION
Bugs in python-can v4.0.0 break the API. Remove as dependency option until bugs are fixed.