### PR TITLE
Check data length sdo server

### DIFF
--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -100,6 +100,12 @@ class LocalNode(BaseNode):
         if check_writable and not obj.writable:
             raise SdoAbortedError(0x06010002)
 
+        # Check length matches type (length of od variable is in bits)
+        if obj.data_type in objectdictionary.NUMBER_TYPES and (
+            not 8 * len(data) == len(obj)
+        ):
+            raise SdoAbortedError(0x06070010)
+
         # Try callbacks
         for callback in self._write_callbacks:
             callback(index=index, subindex=subindex, od=obj, data=data)

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -737,7 +737,6 @@ class BlockDownloadStream(io.RawIOBase):
                                         "block download response")
         if ackseq != self._blksize:
             # Sequence error, try to retransmit
-            self.sdo_client.abort(0x05040003)
             self._retransmit(ackseq, blksize)
             # We should be back in sync
             return
@@ -753,8 +752,8 @@ class BlockDownloadStream(io.RawIOBase):
         logger.info(("%d of %d sequences were received. "
                  "Will start retransmission") % (ackseq, self._blksize))
         # Sub blocks betwen ackseq and end of corrupted block need to be resent
-        # Copy block to resend, and clear it so that multiple retransmits can be done
-        block = self._current_block[ackseq:].copy()
+        # Get the part of the block to resend
+        block = self._current_block[ackseq:]
         # Go back to correct position in stream
         self.pos = self.pos - (len(block) * 7)
         # Reset the _current_block before starting the retransmission

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -71,6 +71,16 @@ class TestSDO(unittest.TestCase):
         value = self.local_node.sdo[0x2004].raw
         self.assertEqual(value, 0xfeff)
 
+    def test_expedited_download_wrong_datatype(self):
+        # Try to write 32 bit in integer16 type
+        with self.assertRaises(canopen.SdoAbortedError) as error:
+            self.remote_node.sdo.download(0x2001, 0x0, bytes([10, 10, 10, 10]))
+        self.assertEqual(error.exception.code, 0x06070010)
+        # Try to write normal 16 bit word, should be ok
+        self.remote_node.sdo.download(0x2001, 0x0, bytes([10, 10]))
+        value = self.remote_node.sdo.upload(0x2001, 0x0)
+        self.assertEqual(value, bytes([10, 10]))
+
     def test_segmented_download(self):
         self.remote_node.sdo[0x2000].raw = "Another cool device"
         value = self.local_node.sdo[0x2000].data


### PR DESCRIPTION
Currently, if writing a value with the wrong size inside object dictionary, no errors are raised.
This can cause all sorts of problem : for example when sending PDO frames, the frame could be greater than 8 bytes, etc.
I added a a length check when the expected datatype is of NUMBER_TYPE.