### PR TITLE
 Remove old callbacks if re-adding a node with the same id

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -268,6 +268,9 @@ class Network(MutableMapping):
 
     def __setitem__(self, node_id: int, node: Union[RemoteNode, LocalNode]):
         assert node_id == node.id
+        if node_id in self.nodes:
+            # Remove old callbacks
+            self.nodes[node_id].remove_network()
         self.nodes[node_id] = node
         node.associate_network(self)
 


### PR DESCRIPTION
Adding a node with the same ID that was previously added on the network would not update the can message callbacks (SDO, NMT, etc..) to the new node object, keeping the old node object callbacks.
This fixes the issue by first checking if the id already exists and removing the callbacks if any.