### PR TITLE
objectdictionary: Use node_id from DCF if not provided

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -87,8 +87,9 @@ def import_eds(source, node_id):
                 pass
 
     if eds.has_section("DeviceComissioning"):
-        od.bitrate = int(eds.get("DeviceComissioning", "BaudRate")) * 1000
+        od.bitrate = int(eds.get("DeviceComissioning", "Baudrate")) * 1000
         od.node_id = int(eds.get("DeviceComissioning", "NodeID"), 0)
+        node_id = node_id or od.node_id
 
     for section in eds.sections():
         # Match dummy definitions


### PR DESCRIPTION
Hi,

When creating a RemoteNode from the objectdictionary, like
```
node = canopen.RemoteNode(None, object_dictionary=config_file)
```
then the variables relative to the `NODEID` are not resolved properly, because the `None` value in `node_id` is not updated before `build_variable` is called.

This should fix that and still keep the user provided node_id, if provided.