### PR TITLE
Change type() into isinstance()

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -29,7 +29,7 @@ def export_od(od, dest:Union[str,TextIO,None]=None, doc_type:Optional[str]=None)
     """
 
     doctypes = {"eds", "dcf"}
-    if type(dest) is str:
+    if isinstance(dest, str):
         if doc_type is None:
             for t in doctypes:
                 if dest.endswith(f".{t}"):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -323,11 +323,11 @@ def export_dcf(od, dest=None, fileInfo={}):
 
 def export_eds(od, dest=None, file_info={}, device_commisioning=False):
     def export_object(obj, eds):
-        if type(obj) is objectdictionary.Variable:
+        if isinstance(obj, objectdictionary.Variable):
             return export_variable(obj, eds)
-        if type(obj) is objectdictionary.Record:
+        if isinstance(obj, objectdictionary.Record):
             return export_record(obj, eds)
-        if type(obj) is objectdictionary.Array:
+        if isinstance(obj, objectdictionary.Array):
             return export_array(obj, eds)
 
     def export_common(var, eds, section):
@@ -337,7 +337,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
             eds.set(section, "StorageLocation", var.storage_location)
 
     def export_variable(var, eds):
-        if type(var.parent) is objectdictionary.ObjectDictionary:
+        if isinstance(var.parent, objectdictionary.ObjectDictionary):
             # top level variable
             section = "%04X" % var.index
         else:
@@ -376,7 +376,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         section = "%04X" % var.index
         export_common(var, eds, section)
         eds.set(section, "SubNumber", "0x%X" % len(var.subindices))
-        ot = RECORD if type(var) is objectdictionary.Record else ARR
+        ot = RECORD if isinstance(var, objectdictionary.Record) else ARR
         eds.set(section, "ObjectType", "0x%X" % ot)
         for i in var:
             export_variable(var[i], eds)
@@ -428,11 +428,11 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         ("LSS_Supported", "LSS_supported"),
     ]:
         val = getattr(od.device_information, odprop, None)
-        if type(val) is None:
+        if val is None:
             continue
-        elif type(val) is str:
+        elif isinstance(val, str):
             eds.set("DeviceInfo", eprop, val)
-        elif type(val) in (int, bool):
+        elif isinstance(val, (int, bool)):
             eds.set("DeviceInfo", eprop, int(val))
 
     # we are also adding out of spec baudrates here.

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -144,7 +144,7 @@ class TestEDS(unittest.TestCase):
                     self.assertEqual(type(actual_object), type(expected_object))
                     self.assertEqual(actual_object.name, expected_object.name)
 
-                    if type(actual_object) is canopen.objectdictionary.Variable:
+                    if isinstance(actual_object, canopen.objectdictionary.Variable):
                         expected_vars = [expected_object]
                         actual_vars = [actual_object]
                     else:


### PR DESCRIPTION
It is generally preferred to use `isinstance()` over `type()` for checking the type of objects. This PR makes some minor cleanups on the use of `type()`.
