### PR TITLE
Import cleanups

### DIFF
--- a/canopen/__init__.py
+++ b/canopen/__init__.py
@@ -1,10 +1,10 @@
-from .network import Network, NodeScanner
-from .node import RemoteNode, LocalNode
-from .sdo import SdoCommunicationError, SdoAbortedError
-from .objectdictionary import import_od, export_od, ObjectDictionary, ObjectDictionaryError
-from .profiles.p402 import BaseNode402
+from canopen.network import Network, NodeScanner
+from canopen.node import RemoteNode, LocalNode
+from canopen.sdo import SdoCommunicationError, SdoAbortedError
+from canopen.objectdictionary import import_od, export_od, ObjectDictionary, ObjectDictionaryError
+from canopen.profiles.p402 import BaseNode402
 try:
-    from ._version import version as __version__
+    from canopen._version import version as __version__
 except ImportError:
     # package is not installed
     __version__ = "unknown"

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -17,13 +17,13 @@ except ImportError:
     class Listener:
         """ Dummy listener """
 
-from .node import RemoteNode, LocalNode
-from .sync import SyncProducer
-from .timestamp import TimeProducer
-from .nmt import NmtMaster
-from .lss import LssMaster
-from .objectdictionary.eds import import_from_node
-from .objectdictionary import ObjectDictionary
+from canopen.node import RemoteNode, LocalNode
+from canopen.sync import SyncProducer
+from canopen.timestamp import TimeProducer
+from canopen.nmt import NmtMaster
+from canopen.lss import LssMaster
+from canopen.objectdictionary.eds import import_from_node
+from canopen.objectdictionary import ObjectDictionary
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -4,8 +4,6 @@ import struct
 import time
 from typing import Callable, Optional
 
-from .network import CanError
-
 logger = logging.getLogger(__name__)
 
 NMT_STATES = {

--- a/canopen/node/__init__.py
+++ b/canopen/node/__init__.py
@@ -1,2 +1,2 @@
-from .remote import RemoteNode
-from .local import LocalNode
+from canopen.node.remote import RemoteNode
+from canopen.node.local import LocalNode

--- a/canopen/node/base.py
+++ b/canopen/node/base.py
@@ -1,5 +1,5 @@
 from typing import TextIO, Union
-from .. import objectdictionary
+from canopen.objectdictionary import ObjectDictionary, import_od
 
 
 class BaseNode:
@@ -15,14 +15,12 @@ class BaseNode:
     def __init__(
         self,
         node_id: int,
-        object_dictionary: Union[objectdictionary.ObjectDictionary, str, TextIO],
+        object_dictionary: Union[ObjectDictionary, str, TextIO],
     ):
         self.network = None
 
-        if not isinstance(object_dictionary,
-                          objectdictionary.ObjectDictionary):
-            object_dictionary = objectdictionary.import_od(
-                object_dictionary, node_id)
+        if not isinstance(object_dictionary, ObjectDictionary):
+            object_dictionary = import_od(object_dictionary, node_id)
         self.object_dictionary = object_dictionary
 
         self.id = node_id or self.object_dictionary.node_id

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Dict, Union
 
-from .base import BaseNode
-from ..sdo import SdoServer, SdoAbortedError
-from ..pdo import PDO, TPDO, RPDO
-from ..nmt import NmtSlave
-from ..emcy import EmcyProducer
-from .. import objectdictionary
+from canopen.node.base import BaseNode
+from canopen.sdo import SdoServer, SdoAbortedError
+from canopen.pdo import PDO, TPDO, RPDO
+from canopen.nmt import NmtSlave
+from canopen.emcy import EmcyProducer
+from canopen.objectdictionary import ObjectDictionary
+from canopen import objectdictionary
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class LocalNode(BaseNode):
     def __init__(
         self,
         node_id: int,
-        object_dictionary: Union[objectdictionary.ObjectDictionary, str],
+        object_dictionary: Union[ObjectDictionary, str],
     ):
         super(LocalNode, self).__init__(node_id, object_dictionary)
 

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -1,16 +1,12 @@
 import logging
 from typing import Union, TextIO
 
-from ..sdo import SdoClient
-from ..nmt import NmtMaster
-from ..emcy import EmcyConsumer
-from ..pdo import TPDO, RPDO, PDO
-from ..objectdictionary import Record, Array, Variable
-from .base import BaseNode
-
-import canopen
-
-from canopen import objectdictionary
+from canopen.sdo import SdoClient, SdoCommunicationError, SdoAbortedError
+from canopen.nmt import NmtMaster
+from canopen.emcy import EmcyConsumer
+from canopen.pdo import TPDO, RPDO, PDO
+from canopen.objectdictionary import Record, Array, Variable, ObjectDictionary
+from canopen.node.base import BaseNode
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +27,7 @@ class RemoteNode(BaseNode):
     def __init__(
         self,
         node_id: int,
-        object_dictionary: Union[objectdictionary.ObjectDictionary, str, TextIO],
+        object_dictionary: Union[ObjectDictionary, str, TextIO],
         load_od: bool = False,
     ):
         super(RemoteNode, self).__init__(node_id, object_dictionary)
@@ -138,9 +134,9 @@ class RemoteNode(BaseNode):
                     index=index,
                     name=name,
                     value=value)))
-        except canopen.SdoCommunicationError as e:
+        except SdoCommunicationError as e:
             logger.warning(str(e))
-        except canopen.SdoAbortedError as e:
+        except SdoAbortedError as e:
             # WORKAROUND for broken implementations: the SDO is set but the error
             # "Attempt to write a read-only object" is raised any way.
             if e.code != 0x06010002:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     from collections import MutableMapping, Mapping
 import logging
 
-from .datatypes import *
+from canopen.objectdictionary.datatypes import *
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +42,10 @@ def export_od(od, dest:Union[str,TextIO,None]=None, doc_type:Optional[str]=None)
     assert doc_type in doctypes
 
     if doc_type == "eds":
-        from . import eds
+        from canopen.objectdictionary import eds
         return eds.export_eds(od, dest)
     elif doc_type == "dcf":
-        from . import eds
+        from canopen.objectdictionary import eds
         return eds.export_dcf(od, dest)
 
 
@@ -74,10 +74,10 @@ def import_od(
         filename = source
     suffix = filename[filename.rfind("."):].lower()
     if suffix in (".eds", ".dcf"):
-        from . import eds
+        from canopen.objectdictionary import eds
         return eds.import_eds(source, node_id)
     elif suffix == ".epf":
-        from . import epf
+        from canopen.objectdictionary import epf
         return epf.import_epf(source)
     else:
         raise NotImplementedError("No support for this format")

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -2,13 +2,13 @@ import copy
 import logging
 import re
 
-from canopen.objectdictionary import datatypes
-
 try:
     from configparser import RawConfigParser, NoOptionError, NoSectionError
 except ImportError:
     from ConfigParser import RawConfigParser, NoOptionError, NoSectionError
+
 from canopen import objectdictionary
+from canopen.objectdictionary import ObjectDictionary, datatypes
 from canopen.sdo import SdoClient
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ def import_eds(source, node_id):
         # Python 2
         eds.readfp(fp)
     fp.close()
-    od = objectdictionary.ObjectDictionary()
+    od = ObjectDictionary()
 
     if eds.has_section("FileInfo"):
         od.__edsFileInfo = {
@@ -126,7 +126,7 @@ def import_eds(source, node_id):
                 arr = objectdictionary.Array(name, index)
                 last_subindex = objectdictionary.Variable(
                     "Number of entries", index, 0)
-                last_subindex.data_type = objectdictionary.UNSIGNED8
+                last_subindex.data_type = datatypes.UNSIGNED8
                 arr.add_member(last_subindex)
                 arr.add_member(build_variable(eds, section, node_id, index, 1))
                 arr.storage_location = storage_location
@@ -175,7 +175,7 @@ def import_from_node(node_id, network):
     :param network: network object
     """
     # Create temporary SDO client
-    sdo_client = SdoClient(0x600 + node_id, 0x580 + node_id, objectdictionary.ObjectDictionary())
+    sdo_client = SdoClient(0x600 + node_id, 0x580 + node_id, ObjectDictionary())
     sdo_client.network = network
     # Subscribe to SDO responses
     network.subscribe(0x580 + node_id, sdo_client.on_response)
@@ -215,11 +215,11 @@ def _signed_int_from_hex(hex_str, bit_length):
 
 
 def _convert_variable(node_id, var_type, value):
-    if var_type in (objectdictionary.OCTET_STRING, objectdictionary.DOMAIN):
+    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
         return bytes.fromhex(value)
-    elif var_type in (objectdictionary.VISIBLE_STRING, objectdictionary.UNICODE_STRING):
+    elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
         return value
-    elif var_type in objectdictionary.FLOAT_TYPES:
+    elif var_type in datatypes.FLOAT_TYPES:
         return float(value)
     else:
         # COB-ID can contain '$NODEID+' so replace this with node_id before converting
@@ -233,11 +233,11 @@ def _convert_variable(node_id, var_type, value):
 def _revert_variable(var_type, value):
     if value is None:
         return None
-    if var_type in (objectdictionary.OCTET_STRING, objectdictionary.DOMAIN):
+    if var_type in (datatypes.OCTET_STRING, datatypes.DOMAIN):
         return bytes.hex(value)
-    elif var_type in (objectdictionary.VISIBLE_STRING, objectdictionary.UNICODE_STRING):
+    elif var_type in (datatypes.VISIBLE_STRING, datatypes.UNICODE_STRING):
         return value
-    elif var_type in objectdictionary.FLOAT_TYPES:
+    elif var_type in datatypes.FLOAT_TYPES:
         return value
     else:
         return "0x%02X" % value
@@ -269,14 +269,14 @@ def build_variable(eds, section, node_id, index, subindex=0):
         except NoSectionError:
             logger.warning("%s has an unknown or unsupported data type (%X)", name, var.data_type)
             # Assume DOMAIN to force application to interpret the byte data
-            var.data_type = objectdictionary.DOMAIN
+            var.data_type = datatypes.DOMAIN
 
     var.pdo_mappable = bool(int(eds.get(section, "PDOMapping", fallback="0"), 0))
 
     if eds.has_option(section, "LowLimit"):
         try:
             min_string = eds.get(section, "LowLimit")
-            if var.data_type in objectdictionary.SIGNED_TYPES:
+            if var.data_type in datatypes.SIGNED_TYPES:
                 var.min = _signed_int_from_hex(min_string, _calc_bit_length(var.data_type))
             else:
                 var.min = int(min_string, 0)
@@ -285,7 +285,7 @@ def build_variable(eds, section, node_id, index, subindex=0):
     if eds.has_option(section, "HighLimit"):
         try:
             max_string = eds.get(section, "HighLimit")
-            if var.data_type in objectdictionary.SIGNED_TYPES:
+            if var.data_type in datatypes.SIGNED_TYPES:
                 var.max = _signed_int_from_hex(max_string, _calc_bit_length(var.data_type))
             else:
                 var.max = int(max_string, 0)
@@ -337,7 +337,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
             eds.set(section, "StorageLocation", var.storage_location)
 
     def export_variable(var, eds):
-        if isinstance(var.parent, objectdictionary.ObjectDictionary):
+        if isinstance(var.parent, ObjectDictionary):
             # top level variable
             section = "%04X" % var.index
         else:

--- a/canopen/objectdictionary/epf.py
+++ b/canopen/objectdictionary/epf.py
@@ -3,7 +3,9 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 import logging
+
 from canopen import objectdictionary
+from canopen.objectdictionary import ObjectDictionary
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +34,7 @@ def import_epf(epf):
         The Object Dictionary.
     :rtype: canopen.ObjectDictionary
     """
-    od = objectdictionary.ObjectDictionary()
+    od = ObjectDictionary()
     if etree.iselement(epf):
         tree = epf
     else:

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,8 +1,7 @@
-from .base import PdoBase, Maps, Map, Variable
-
 import logging
-import itertools
-import canopen
+
+from canopen import node
+from canopen.pdo.base import PdoBase, Maps, Map, Variable
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +44,7 @@ class RPDO(PdoBase):
         :raise TypeError: Exception is thrown if the node associated with the PDO does not
         support this function.
         """
-        if isinstance(self.node, canopen.RemoteNode):
+        if isinstance(self.node, node.RemoteNode):
             for pdo in self.map.values():
                 pdo.stop()
         else:
@@ -70,7 +69,7 @@ class TPDO(PdoBase):
         :raise TypeError: Exception is thrown if the node associated with the PDO does not
         support this function.
         """
-        if isinstance(canopen.LocalNode, self.node):
+        if isinstance(self.node, node.LocalNode):
             for pdo in self.map.values():
                 pdo.stop()
         else:

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -8,9 +8,9 @@ except ImportError:
 import logging
 import binascii
 
-from ..sdo import SdoAbortedError
-from .. import objectdictionary
-from .. import variable
+from canopen.sdo import SdoAbortedError
+from canopen import objectdictionary
+from canopen import variable
 
 PDO_NOT_VALID = 1 << 31
 RTR_NOT_ALLOWED = 1 << 30

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -1,8 +1,9 @@
 # inspired by the NmtMaster code
 import logging
 import time
-from ..node import RemoteNode
-from ..sdo import SdoCommunicationError
+
+from canopen.node import RemoteNode
+from canopen.sdo import SdoCommunicationError
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/sdo/__init__.py
+++ b/canopen/sdo/__init__.py
@@ -1,4 +1,4 @@
-from .base import Variable, Record, Array
-from .client import SdoClient
-from .server import SdoServer
-from .exceptions import SdoAbortedError, SdoCommunicationError
+from canopen.sdo.base import Variable, Record, Array
+from canopen.sdo.client import SdoClient
+from canopen.sdo.server import SdoServer
+from canopen.sdo.exceptions import SdoAbortedError, SdoCommunicationError

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -5,8 +5,9 @@ try:
 except ImportError:
     from collections import Mapping
 
-from .. import objectdictionary
-from .. import variable
+from canopen import objectdictionary
+from canopen.objectdictionary import ObjectDictionary
+from canopen import variable
 
 
 class CrcXmodem:
@@ -31,7 +32,7 @@ class SdoBase(Mapping):
         self,
         rx_cobid: int,
         tx_cobid: int,
-        od: objectdictionary.ObjectDictionary,
+        od: ObjectDictionary,
     ):
         """
         :param rx_cobid:
@@ -81,7 +82,7 @@ class SdoBase(Mapping):
 
 class Record(Mapping):
 
-    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
         self.sdo_node = sdo_node
         self.od = od
 
@@ -100,7 +101,7 @@ class Record(Mapping):
 
 class Array(Mapping):
 
-    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
         self.sdo_node = sdo_node
         self.od = od
 
@@ -120,7 +121,7 @@ class Array(Mapping):
 class Variable(variable.Variable):
     """Access object dictionary variable values using SDO protocol."""
 
-    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
         self.sdo_node = sdo_node
         variable.Variable.__init__(self, od)
 

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -7,12 +7,11 @@ try:
 except ImportError:
     import Queue as queue
 
-from ..network import CanError
-from .. import objectdictionary
-
-from .base import SdoBase
-from .constants import *
-from .exceptions import *
+from canopen.network import CanError
+from canopen import objectdictionary
+from canopen.sdo.base import SdoBase
+from canopen.sdo.constants import *
+from canopen.sdo.exceptions import *
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +192,7 @@ class SdoClient(SdoBase):
             Force use of segmented download regardless of data size.
         :param bool request_crc_support:
             If crc calculation should be requested when using block transfer
-        
+
         :returns:
             A file like object.
         """

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -1,8 +1,8 @@
 import logging
 
-from .base import SdoBase
-from .constants import *
-from .exceptions import *
+from canopen.sdo.base import SdoBase
+from canopen.sdo.constants import *
+from canopen.sdo.exceptions import *
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/sync.py
+++ b/canopen/sync.py
@@ -1,5 +1,3 @@
-
-
 from typing import Optional
 
 

--- a/canopen/variable.py
+++ b/canopen/variable.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from collections import Mapping
 
-from . import objectdictionary
+from canopen import objectdictionary
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR is an overhaul on the imports within canopen. To make the package consistent, every import is now using absolute imports, e.g. `import canopen.something`

* Use absolute `canopen` instead of relative imports
* Ensure canopen imports after system imports
* Fix isinstance bug in TPDO.stop()
* Change const from objectdictionary.* to datatypes.* in objectdictionary.eds.py for consistency
* Save typing by using ObjectDictionary instead of objectdictionary.ObjectDictionary