### PR TITLE
Rename Variable, Record and Array (#363)

### DIFF
--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -119,7 +119,7 @@ class LocalNode(BaseNode):
             # Index does not exist
             raise SdoAbortedError(0x06020000)
         obj = self.object_dictionary[index]
-        if not isinstance(obj, objectdictionary.Variable):
+        if not isinstance(obj, objectdictionary.ODVariable):
             # Group or array
             if subindex not in obj:
                 # Subindex does not exist

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -5,7 +5,7 @@ from ..sdo import SdoClient
 from ..nmt import NmtMaster
 from ..emcy import EmcyConsumer
 from ..pdo import TPDO, RPDO, PDO
-from ..objectdictionary import Record, Array, Variable
+from ..objectdictionary import ODRecord, ODArray, ODVariable
 from .base import BaseNode
 
 import canopen
@@ -152,10 +152,10 @@ class RemoteNode(BaseNode):
     def load_configuration(self):
         ''' Load the configuration of the node from the object dictionary.'''
         for obj in self.object_dictionary.values():
-            if isinstance(obj, Record) or isinstance(obj, Array):
+            if isinstance(obj, ODRecord) or isinstance(obj, ODArray):
                 for subobj in obj.values():
-                    if isinstance(subobj, Variable) and subobj.writable and (subobj.value is not None):
+                    if isinstance(subobj, ODVariable) and subobj.writable and (subobj.value is not None):
                         self.__load_configuration_helper(subobj.index, subobj.subindex, subobj.name, subobj.value)
-            elif isinstance(obj, Variable) and obj.writable and (obj.value is not None):
+            elif isinstance(obj, ODVariable) and obj.writable and (obj.value is not None):
                 self.__load_configuration_helper(obj.index, None, obj.name, obj.value)
         self.pdo.read()  # reads the new configuration from the driver

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -103,7 +103,7 @@ class ObjectDictionary(MutableMapping):
 
     def __getitem__(
         self, index: Union[int, str]
-    ) -> Union["Array", "Record", "Variable"]:
+    ) -> Union["ODArray", "ODRecord", "ODVariable"]:
         """Get object from object dictionary by name or index."""
         item = self.names.get(index) or self.indices.get(index)
         if item is None:
@@ -112,7 +112,7 @@ class ObjectDictionary(MutableMapping):
         return item
 
     def __setitem__(
-        self, index: Union[int, str], obj: Union["Array", "Record", "Variable"]
+        self, index: Union[int, str], obj: Union["ODArray", "ODRecord", "ODVariable"]
     ):
         assert index == obj.index or index == obj.name
         self.add_object(obj)
@@ -131,14 +131,14 @@ class ObjectDictionary(MutableMapping):
     def __contains__(self, index: Union[int, str]):
         return index in self.names or index in self.indices
 
-    def add_object(self, obj: Union["Array", "Record", "Variable"]) -> None:
+    def add_object(self, obj: Union["ODArray", "ODRecord", "ODVariable"]) -> None:
         """Add object to the object dictionary.
 
         :param obj:
             Should be either one of
-            :class:`~canopen.objectdictionary.Variable`,
-            :class:`~canopen.objectdictionary.Record`, or
-            :class:`~canopen.objectdictionary.Array`.
+            :class:`~canopen.objectdictionary.ODVariable`,
+            :class:`~canopen.objectdictionary.ODRecord`, or
+            :class:`~canopen.objectdictionary.ODArray`.
         """
         obj.parent = self
         self.indices[obj.index] = obj
@@ -146,20 +146,20 @@ class ObjectDictionary(MutableMapping):
 
     def get_variable(
         self, index: Union[int, str], subindex: int = 0
-    ) -> Optional["Variable"]:
+    ) -> Optional["ODVariable"]:
         """Get the variable object at specified index (and subindex if applicable).
 
-        :return: Variable if found, else `None`
+        :return: ODVariable if found, else `None`
         """
         obj = self.get(index)
-        if isinstance(obj, Variable):
+        if isinstance(obj, ODVariable):
             return obj
-        elif isinstance(obj, (Record, Array)):
+        elif isinstance(obj, (ODRecord, ODArray)):
             return obj.get(subindex)
 
 
-class Record(MutableMapping):
-    """Groups multiple :class:`~canopen.objectdictionary.Variable` objects using
+class ODRecord(MutableMapping):
+    """Groups multiple :class:`~canopen.objectdictionary.ODVariable` objects using
     subindices.
     """
 
@@ -178,13 +178,13 @@ class Record(MutableMapping):
         self.subindices = {}
         self.names = {}
 
-    def __getitem__(self, subindex: Union[int, str]) -> "Variable":
+    def __getitem__(self, subindex: Union[int, str]) -> "ODVariable":
         item = self.names.get(subindex) or self.subindices.get(subindex)
         if item is None:
             raise KeyError("Subindex %s was not found" % subindex)
         return item
 
-    def __setitem__(self, subindex: Union[int, str], var: "Variable"):
+    def __setitem__(self, subindex: Union[int, str], var: "ODVariable"):
         assert subindex == var.subindex
         self.add_member(var)
 
@@ -202,18 +202,18 @@ class Record(MutableMapping):
     def __contains__(self, subindex: Union[int, str]) -> bool:
         return subindex in self.names or subindex in self.subindices
 
-    def __eq__(self, other: "Record") -> bool:
+    def __eq__(self, other: "ODRecord") -> bool:
         return self.index == other.index
 
-    def add_member(self, variable: "Variable") -> None:
-        """Adds a :class:`~canopen.objectdictionary.Variable` to the record."""
+    def add_member(self, variable: "ODVariable") -> None:
+        """Adds a :class:`~canopen.objectdictionary.ODVariable` to the record."""
         variable.parent = self
         self.subindices[variable.subindex] = variable
         self.names[variable.name] = variable
 
 
-class Array(Mapping):
-    """An array of :class:`~canopen.objectdictionary.Variable` objects using
+class ODArray(Mapping):
+    """An array of :class:`~canopen.objectdictionary.ODVariable` objects using
     subindices.
 
     Actual length of array must be read from the node using SDO.
@@ -234,7 +234,7 @@ class Array(Mapping):
         self.subindices = {}
         self.names = {}
 
-    def __getitem__(self, subindex: Union[int, str]) -> "Variable":
+    def __getitem__(self, subindex: Union[int, str]) -> "ODVariable":
         var = self.names.get(subindex) or self.subindices.get(subindex)
         if var is not None:
             # This subindex is defined
@@ -243,7 +243,7 @@ class Array(Mapping):
             # Create a new variable based on first array item
             template = self.subindices[1]
             name = "%s_%x" % (template.name, subindex)
-            var = Variable(name, self.index, subindex)
+            var = ODVariable(name, self.index, subindex)
             var.parent = self
             for attr in ("data_type", "unit", "factor", "min", "max", "default",
                          "access_type", "description", "value_descriptions",
@@ -260,17 +260,17 @@ class Array(Mapping):
     def __iter__(self) -> Iterable[int]:
         return iter(sorted(self.subindices))
 
-    def __eq__(self, other: "Array") -> bool:
+    def __eq__(self, other: "ODArray") -> bool:
         return self.index == other.index
 
-    def add_member(self, variable: "Variable") -> None:
-        """Adds a :class:`~canopen.objectdictionary.Variable` to the record."""
+    def add_member(self, variable: "ODVariable") -> None:
+        """Adds a :class:`~canopen.objectdictionary.ODVariable` to the record."""
         variable.parent = self
         self.subindices[variable.subindex] = variable
         self.names[variable.name] = variable
 
 
-class Variable:
+class ODVariable:
     """Simple variable."""
 
     STRUCT_TYPES = {
@@ -289,8 +289,8 @@ class Variable:
 
     def __init__(self, name: str, index: int, subindex: int = 0):
         #: The :class:`~canopen.ObjectDictionary`,
-        #: :class:`~canopen.objectdictionary.Record` or
-        #: :class:`~canopen.objectdictionary.Array` owning the variable
+        #: :class:`~canopen.objectdictionary.ODRecord` or
+        #: :class:`~canopen.objectdictionary.ODArray` owning the variable
         self.parent = None
         #: 16-bit address of the object in the dictionary
         self.index = index
@@ -328,7 +328,7 @@ class Variable:
         self.pdo_mappable = False
 
 
-    def __eq__(self, other: "Variable") -> bool:
+    def __eq__(self, other: "ODVariable") -> bool:
         return (self.index == other.index and
                 self.subindex == other.subindex)
 
@@ -486,3 +486,9 @@ class DeviceInformation:
 
 class ObjectDictionaryError(Exception):
     """Unsupported operation with the current Object Dictionary."""
+
+
+# Compatibility for old names
+Record = ODRecord
+Array = ODArray
+Variable = ODVariable

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -101,7 +101,7 @@ def import_eds(source, node_id):
             for i in range(1, 8):
                 key = "Dummy%04d" % i
                 if eds.getint(section, key) == 1:
-                    var = objectdictionary.Variable(key, i, 0)
+                    var = objectdictionary.ODVariable(key, i, 0)
                     var.data_type = i
                     var.access_type = "const"
                     od.add_object(var)
@@ -127,8 +127,8 @@ def import_eds(source, node_id):
                 var = build_variable(eds, section, node_id, index)
                 od.add_object(var)
             elif object_type == ARR and eds.has_option(section, "CompactSubObj"):
-                arr = objectdictionary.Array(name, index)
-                last_subindex = objectdictionary.Variable(
+                arr = objectdictionary.ODArray(name, index)
+                last_subindex = objectdictionary.ODVariable(
                     "Number of entries", index, 0)
                 last_subindex.data_type = objectdictionary.UNSIGNED8
                 arr.add_member(last_subindex)
@@ -136,11 +136,11 @@ def import_eds(source, node_id):
                 arr.storage_location = storage_location
                 od.add_object(arr)
             elif object_type == ARR:
-                arr = objectdictionary.Array(name, index)
+                arr = objectdictionary.ODArray(name, index)
                 arr.storage_location = storage_location
                 od.add_object(arr)
             elif object_type == RECORD:
-                record = objectdictionary.Record(name, index)
+                record = objectdictionary.ODRecord(name, index)
                 record.storage_location = storage_location
                 od.add_object(record)
 
@@ -152,8 +152,8 @@ def import_eds(source, node_id):
             index = int(match.group(1), 16)
             subindex = int(match.group(2), 16)
             entry = od[index]
-            if isinstance(entry, (objectdictionary.Record,
-                                  objectdictionary.Array)):
+            if isinstance(entry, (objectdictionary.ODRecord,
+                                  objectdictionary.ODArray)):
                 var = build_variable(eds, section, node_id, index, subindex)
                 entry.add_member(var)
 
@@ -256,7 +256,7 @@ def build_variable(eds, section, node_id, index, subindex=0):
     :param subindex: Subindex of the CANOpen object (if presente, else 0)
     """
     name = eds.get(section, "ParameterName")
-    var = objectdictionary.Variable(name, index, subindex)
+    var = objectdictionary.ODVariable(name, index, subindex)
     try:
         var.storage_location = eds.get(section, "StorageLocation")
     except NoOptionError:
@@ -327,11 +327,11 @@ def export_dcf(od, dest=None, fileInfo={}):
 
 def export_eds(od, dest=None, file_info={}, device_commisioning=False):
     def export_object(obj, eds):
-        if isinstance(obj, objectdictionary.Variable):
+        if isinstance(obj, objectdictionary.ODVariable):
             return export_variable(obj, eds)
-        if isinstance(obj, objectdictionary.Record):
+        if isinstance(obj, objectdictionary.ODRecord):
             return export_record(obj, eds)
-        if isinstance(obj, objectdictionary.Array):
+        if isinstance(obj, objectdictionary.ODArray):
             return export_array(obj, eds)
 
     def export_common(var, eds, section):
@@ -380,7 +380,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         section = "%04X" % var.index
         export_common(var, eds, section)
         eds.set(section, "SubNumber", "0x%X" % len(var.subindices))
-        ot = RECORD if isinstance(var, objectdictionary.Record) else ARR
+        ot = RECORD if isinstance(var, objectdictionary.ODRecord) else ARR
         eds.set(section, "ObjectType", "0x%X" % ot)
         for i in var:
             export_variable(var[i], eds)

--- a/canopen/objectdictionary/epf.py
+++ b/canopen/objectdictionary/epf.py
@@ -59,7 +59,7 @@ def import_epf(epf):
             od.add_object(var)
         elif len(parameters) == 2 and parameters[1].get("ObjectType") == "ARRAY":
             # Array
-            arr = objectdictionary.Array(name, index)
+            arr = objectdictionary.ODArray(name, index)
             for par_tree in parameters:
                 var = build_variable(par_tree)
                 arr.add_member(var)
@@ -69,7 +69,7 @@ def import_epf(epf):
             od.add_object(arr)
         else:
             # Complex record
-            record = objectdictionary.Record(name, index)
+            record = objectdictionary.ODRecord(name, index)
             for par_tree in parameters:
                 var = build_variable(par_tree)
                 record.add_member(var)
@@ -87,7 +87,7 @@ def build_variable(par_tree):
     name = par_tree.get("SymbolName")
     data_type = par_tree.get("DataType")
 
-    par = objectdictionary.Variable(name, index, subindex)
+    par = objectdictionary.ODVariable(name, index, subindex)
     factor = par_tree.get("Factor", "1")
     par.factor = int(factor) if factor.isdigit() else float(factor)
     unit = par_tree.get("Unit")

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,8 +1,11 @@
-from .base import PdoBase, Maps, Map, Variable
+from .base import PdoBase, Maps, Map, PdoVariable
 
 import logging
 import itertools
 import canopen
+
+# Compatibility
+from .base import Variable
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/sdo/__init__.py
+++ b/canopen/sdo/__init__.py
@@ -1,4 +1,7 @@
-from .base import Variable, Record, Array
+from .base import SdoVariable, SdoRecord, SdoArray
 from .client import SdoClient
 from .server import SdoServer
 from .exceptions import SdoAbortedError, SdoCommunicationError
+
+# Compatibility
+from .base import Variable, Record, Array

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -48,14 +48,14 @@ class SdoBase(Mapping):
 
     def __getitem__(
         self, index: Union[str, int]
-    ) -> Union["Variable", "Array", "Record"]:
+    ) -> Union["SdoVariable", "SdoArray", "SdoRecord"]:
         entry = self.od[index]
-        if isinstance(entry, objectdictionary.Variable):
-            return Variable(self, entry)
-        elif isinstance(entry, objectdictionary.Array):
-            return Array(self, entry)
-        elif isinstance(entry, objectdictionary.Record):
-            return Record(self, entry)
+        if isinstance(entry, objectdictionary.ODVariable):
+            return SdoVariable(self, entry)
+        elif isinstance(entry, objectdictionary.ODArray):
+            return SdoArray(self, entry)
+        elif isinstance(entry, objectdictionary.ODRecord):
+            return SdoRecord(self, entry)
 
     def __iter__(self) -> Iterable[int]:
         return iter(self.od)
@@ -79,14 +79,14 @@ class SdoBase(Mapping):
         raise NotImplementedError()
 
 
-class Record(Mapping):
+class SdoRecord(Mapping):
 
     def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
         self.sdo_node = sdo_node
         self.od = od
 
-    def __getitem__(self, subindex: Union[int, str]) -> "Variable":
-        return Variable(self.sdo_node, self.od[subindex])
+    def __getitem__(self, subindex: Union[int, str]) -> "SdoVariable":
+        return SdoVariable(self.sdo_node, self.od[subindex])
 
     def __iter__(self) -> Iterable[int]:
         return iter(self.od)
@@ -98,14 +98,14 @@ class Record(Mapping):
         return subindex in self.od
 
 
-class Array(Mapping):
+class SdoArray(Mapping):
 
     def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
         self.sdo_node = sdo_node
         self.od = od
 
-    def __getitem__(self, subindex: Union[int, str]) -> "Variable":
-        return Variable(self.sdo_node, self.od[subindex])
+    def __getitem__(self, subindex: Union[int, str]) -> "SdoVariable":
+        return SdoVariable(self.sdo_node, self.od[subindex])
 
     def __iter__(self) -> Iterable[int]:
         return iter(range(1, len(self) + 1))
@@ -117,7 +117,7 @@ class Array(Mapping):
         return 0 <= subindex <= len(self)
 
 
-class Variable(variable.Variable):
+class SdoVariable(variable.Variable):
     """Access object dictionary variable values using SDO protocol."""
 
     def __init__(self, sdo_node: SdoBase, od: objectdictionary.ObjectDictionary):
@@ -164,3 +164,9 @@ class Variable(variable.Variable):
         """
         return self.sdo_node.open(self.od.index, self.od.subindex, mode,
                                   encoding, buffering, size, block_transfer, request_crc_support=request_crc_support)
+
+
+# For compatibility
+Record = SdoRecord
+Array = SdoArray
+Variable = SdoVariable

--- a/canopen/variable.py
+++ b/canopen/variable.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 
 class Variable:
 
-    def __init__(self, od: objectdictionary.Variable):
+    def __init__(self, od: objectdictionary.ODVariable):
         self.od = od
         #: Description of this variable from Object Dictionary, overridable
         self.name = od.name
-        if isinstance(od.parent, (objectdictionary.Record,
-                                  objectdictionary.Array)):
+        if isinstance(od.parent, (objectdictionary.ODRecord,
+                                  objectdictionary.ODArray)):
             # Include the parent object's name for subentries
             self.name = od.parent.name + "." + od.name
         #: Holds a local, overridable copy of the Object Index

--- a/doc/od.rst
+++ b/doc/od.rst
@@ -40,7 +40,7 @@ Here is an example where the entire object dictionary gets printed out::
     node = network.add_node(6, 'od.eds')
     for obj in node.object_dictionary.values():
         print('0x%X: %s' % (obj.index, obj.name))
-        if isinstance(obj, canopen.objectdictionary.Record):
+        if isinstance(obj, canopen.objectdictionary.ODRecord):
             for subobj in obj.values():
                 print('  %d: %s' % (subobj.subindex, subobj.name))
 
@@ -79,7 +79,7 @@ API
       Return a list of objects (records, arrays and variables).
 
 
-.. autoclass:: canopen.objectdictionary.Variable
+.. autoclass:: canopen.objectdictionary.ODVariable
    :members:
 
    .. describe:: len(var)
@@ -91,12 +91,12 @@ API
       Return ``True`` if the variables have the same index and subindex.
 
 
-.. autoclass:: canopen.objectdictionary.Record
+.. autoclass:: canopen.objectdictionary.ODRecord
    :members:
 
    .. describe:: record[subindex]
 
-      Return the :class:`~canopen.objectdictionary.Variable` for the specified
+      Return the :class:`~canopen.objectdictionary.ODVariable` for the specified
       subindex (as int) or name (as string).
 
    .. describe:: iter(record)
@@ -118,15 +118,15 @@ API
 
    .. method:: values()
 
-      Return a list of :class:`~canopen.objectdictionary.Variable` in the record.
+      Return a list of :class:`~canopen.objectdictionary.ODVariable` in the record.
 
 
-.. autoclass:: canopen.objectdictionary.Array
+.. autoclass:: canopen.objectdictionary.ODArray
    :members:
 
    .. describe:: array[subindex]
 
-      Return the :class:`~canopen.objectdictionary.Variable` for the specified
+      Return the :class:`~canopen.objectdictionary.ODVariable` for the specified
       subindex (as int) or name (as string).
       This will work for all subindexes between 1 and 255. If the requested
       subindex has not been specified in the object dictionary, it will be

--- a/doc/pdo.rst
+++ b/doc/pdo.rst
@@ -106,22 +106,22 @@ API
 
    .. describe:: map[name]
 
-      Return the :class:`canopen.pdo.Variable` for the variable specified as
+      Return the :class:`canopen.pdo.PdoVariable` for the variable specified as
       ``"Group.Variable"`` or ``"Variable"`` or as a position starting at 0.
 
    .. describe:: iter(map)
 
-      Return an iterator of the :class:`canopen.pdo.Variable` entries in the map.
+      Return an iterator of the :class:`canopen.pdo.PdoVariable` entries in the map.
 
    .. describe:: len(map)
 
       Return the number of variables in the map.
 
 
-.. autoclass:: canopen.pdo.Variable
+.. autoclass:: canopen.pdo.PdoVariable
    :members:
    :inherited-members:
 
    .. py:attribute:: od
 
-      The :class:`canopen.objectdictionary.Variable` associated with this object.
+      The :class:`canopen.objectdictionary.ODVariable` associated with this object.

--- a/doc/sdo.rst
+++ b/doc/sdo.rst
@@ -163,25 +163,25 @@ API
        Return a list of objects (records, arrays and variables).
 
 
-.. autoclass:: canopen.sdo.Variable
+.. autoclass:: canopen.sdo.SdoVariable
     :members:
     :inherited-members:
 
     .. py:attribute:: od
 
-       The :class:`canopen.objectdictionary.Variable` associated with this object.
+       The :class:`canopen.objectdictionary.ODVariable` associated with this object.
 
 
-.. autoclass:: canopen.sdo.Record
+.. autoclass:: canopen.sdo.SdoRecord
     :members:
 
     .. py:attribute:: od
 
-       The :class:`canopen.objectdictionary.Record` associated with this object.
+       The :class:`canopen.objectdictionary.ODRecord` associated with this object.
 
     .. describe:: record[subindex]
 
-       Return the :class:`canopen.sdo.Variable` for the specified subindex
+       Return the :class:`canopen.sdo.SdoVariable` for the specified subindex
        (as int) or name (as string).
 
     .. describe:: iter(record)
@@ -199,19 +199,19 @@ API
 
     .. method:: values()
 
-       Return a list of :class:`canopen.sdo.Variable` in the record.
+       Return a list of :class:`canopen.sdo.SdoVariable` in the record.
 
 
-.. autoclass:: canopen.sdo.Array
+.. autoclass:: canopen.sdo.SdoArray
     :members:
 
     .. py:attribute:: od
 
-       The :class:`canopen.objectdictionary.Array` associated with this object.
+       The :class:`canopen.objectdictionary.ODArray` associated with this object.
 
     .. describe:: array[subindex]
 
-       Return the :class:`canopen.sdo.Variable` for the specified subindex
+       Return the :class:`canopen.sdo.SdoVariable` for the specified subindex
        (as int) or name (as string).
 
     .. describe:: iter(array)
@@ -234,7 +234,7 @@ API
 
     .. method:: values()
 
-       Return a list of :class:`canopen.sdo.Variable` in the array.
+       Return a list of :class:`canopen.sdo.SdoVariable` in the array.
        This will make a SDO read operation on subindex 0 in order to get the
        actual length of the array.
 

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -21,7 +21,7 @@ class TestEDS(unittest.TestCase):
 
     def test_variable(self):
         var = self.od['Producer heartbeat time']
-        self.assertIsInstance(var, canopen.objectdictionary.Variable)
+        self.assertIsInstance(var, canopen.objectdictionary.ODVariable)
         self.assertEqual(var.index, 0x1017)
         self.assertEqual(var.subindex, 0)
         self.assertEqual(var.name, 'Producer heartbeat time')
@@ -37,12 +37,12 @@ class TestEDS(unittest.TestCase):
 
     def test_record(self):
         record = self.od['Identity object']
-        self.assertIsInstance(record, canopen.objectdictionary.Record)
+        self.assertIsInstance(record, canopen.objectdictionary.ODRecord)
         self.assertEqual(len(record), 5)
         self.assertEqual(record.index, 0x1018)
         self.assertEqual(record.name, 'Identity object')
         var = record['Vendor-ID']
-        self.assertIsInstance(var, canopen.objectdictionary.Variable)
+        self.assertIsInstance(var, canopen.objectdictionary.ODVariable)
         self.assertEqual(var.name, 'Vendor-ID')
         self.assertEqual(var.index, 0x1018)
         self.assertEqual(var.subindex, 1)
@@ -65,11 +65,11 @@ class TestEDS(unittest.TestCase):
 
     def test_array_compact_subobj(self):
         array = self.od[0x1003]
-        self.assertIsInstance(array, canopen.objectdictionary.Array)
+        self.assertIsInstance(array, canopen.objectdictionary.ODArray)
         self.assertEqual(array.index, 0x1003)
         self.assertEqual(array.name, 'Pre-defined error field')
         var = array[5]
-        self.assertIsInstance(var, canopen.objectdictionary.Variable)
+        self.assertIsInstance(var, canopen.objectdictionary.ODVariable)
         self.assertEqual(var.name, 'Pre-defined error field_5')
         self.assertEqual(var.index, 0x1003)
         self.assertEqual(var.subindex, 5)
@@ -100,7 +100,7 @@ class TestEDS(unittest.TestCase):
 
     def test_dummy_variable(self):
         var = self.od['Dummy0003']
-        self.assertIsInstance(var, canopen.objectdictionary.Variable)
+        self.assertIsInstance(var, canopen.objectdictionary.ODVariable)
         self.assertEqual(var.index, 0x0003)
         self.assertEqual(var.subindex, 0)
         self.assertEqual(var.name, 'Dummy0003')
@@ -145,7 +145,7 @@ class TestEDS(unittest.TestCase):
                     self.assertEqual(type(actual_object), type(expected_object))
                     self.assertEqual(actual_object.name, expected_object.name)
 
-                    if isinstance(actual_object, canopen.objectdictionary.Variable):
+                    if isinstance(actual_object, canopen.objectdictionary.ODVariable):
                         expected_vars = [expected_object]
                         actual_vars = [actual_object]
                     else:

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -5,7 +5,7 @@ from canopen import objectdictionary as od
 class TestDataConversions(unittest.TestCase):
 
     def test_boolean(self):
-        var = od.Variable("Test BOOLEAN", 0x1000)
+        var = od.ODVariable("Test BOOLEAN", 0x1000)
         var.data_type = od.BOOLEAN
         self.assertEqual(var.decode_raw(b"\x01"), True)
         self.assertEqual(var.decode_raw(b"\x00"), False)
@@ -13,25 +13,25 @@ class TestDataConversions(unittest.TestCase):
         self.assertEqual(var.encode_raw(False), b"\x00")
 
     def test_unsigned8(self):
-        var = od.Variable("Test UNSIGNED8", 0x1000)
+        var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8
         self.assertEqual(var.decode_raw(b"\xff"), 255)
         self.assertEqual(var.encode_raw(254), b"\xfe")
 
     def test_unsigned16(self):
-        var = od.Variable("Test UNSIGNED16", 0x1000)
+        var = od.ODVariable("Test UNSIGNED16", 0x1000)
         var.data_type = od.UNSIGNED16
         self.assertEqual(var.decode_raw(b"\xfe\xff"), 65534)
         self.assertEqual(var.encode_raw(65534), b"\xfe\xff")
 
     def test_unsigned32(self):
-        var = od.Variable("Test UNSIGNED32", 0x1000)
+        var = od.ODVariable("Test UNSIGNED32", 0x1000)
         var.data_type = od.UNSIGNED32
         self.assertEqual(var.decode_raw(b"\xfc\xfd\xfe\xff"), 4294901244)
         self.assertEqual(var.encode_raw(4294901244), b"\xfc\xfd\xfe\xff")
 
     def test_integer8(self):
-        var = od.Variable("Test INTEGER8", 0x1000)
+        var = od.ODVariable("Test INTEGER8", 0x1000)
         var.data_type = od.INTEGER8
         self.assertEqual(var.decode_raw(b"\xff"), -1)
         self.assertEqual(var.decode_raw(b"\x7f"), 127)
@@ -39,7 +39,7 @@ class TestDataConversions(unittest.TestCase):
         self.assertEqual(var.encode_raw(127), b"\x7f")
 
     def test_integer16(self):
-        var = od.Variable("Test INTEGER16", 0x1000)
+        var = od.ODVariable("Test INTEGER16", 0x1000)
         var.data_type = od.INTEGER16
         self.assertEqual(var.decode_raw(b"\xfe\xff"), -2)
         self.assertEqual(var.decode_raw(b"\x01\x00"), 1)
@@ -47,13 +47,13 @@ class TestDataConversions(unittest.TestCase):
         self.assertEqual(var.encode_raw(1), b"\x01\x00")
 
     def test_integer32(self):
-        var = od.Variable("Test INTEGER32", 0x1000)
+        var = od.ODVariable("Test INTEGER32", 0x1000)
         var.data_type = od.INTEGER32
         self.assertEqual(var.decode_raw(b"\xfe\xff\xff\xff"), -2)
         self.assertEqual(var.encode_raw(-2), b"\xfe\xff\xff\xff")
 
     def test_visible_string(self):
-        var = od.Variable("Test VISIBLE_STRING", 0x1000)
+        var = od.ODVariable("Test VISIBLE_STRING", 0x1000)
         var.data_type = od.VISIBLE_STRING
         self.assertEqual(var.decode_raw(b"abcdefg"), "abcdefg")
         self.assertEqual(var.decode_raw(b"zero terminated\x00"), "zero terminated")
@@ -63,7 +63,7 @@ class TestDataConversions(unittest.TestCase):
 class TestAlternativeRepresentations(unittest.TestCase):
 
     def test_phys(self):
-        var = od.Variable("Test INTEGER16", 0x1000)
+        var = od.ODVariable("Test INTEGER16", 0x1000)
         var.data_type = od.INTEGER16
         var.factor = 0.1
 
@@ -71,7 +71,7 @@ class TestAlternativeRepresentations(unittest.TestCase):
         self.assertEqual(var.encode_phys(-0.1), -1)
 
     def test_desc(self):
-        var = od.Variable("Test UNSIGNED8", 0x1000)
+        var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8
         var.add_value_description(0, "Value 0")
         var.add_value_description(1, "Value 1")
@@ -82,7 +82,7 @@ class TestAlternativeRepresentations(unittest.TestCase):
         self.assertEqual(var.encode_desc("Value 1"), 1)
 
     def test_bits(self):
-        var = od.Variable("Test UNSIGNED8", 0x1000)
+        var = od.ODVariable("Test UNSIGNED8", 0x1000)
         var.data_type = od.UNSIGNED8
         var.add_bit_definition("BIT 0", [0])
         var.add_bit_definition("BIT 2 and 3", [2, 3])
@@ -99,15 +99,15 @@ class TestObjectDictionary(unittest.TestCase):
 
     def test_add_variable(self):
         test_od = od.ObjectDictionary()
-        var = od.Variable("Test Variable", 0x1000)
+        var = od.ODVariable("Test Variable", 0x1000)
         test_od.add_object(var)
         self.assertEqual(test_od["Test Variable"], var)
         self.assertEqual(test_od[0x1000], var)
 
     def test_add_record(self):
         test_od = od.ObjectDictionary()
-        record = od.Record("Test Record", 0x1001)
-        var = od.Variable("Test Subindex", 0x1001, 1)
+        record = od.ODRecord("Test Record", 0x1001)
+        var = od.ODVariable("Test Subindex", 0x1001, 1)
         record.add_member(var)
         test_od.add_object(record)
         self.assertEqual(test_od["Test Record"], record)
@@ -116,8 +116,8 @@ class TestObjectDictionary(unittest.TestCase):
 
     def test_add_array(self):
         test_od = od.ObjectDictionary()
-        array = od.Array("Test Array", 0x1002)
-        array.add_member(od.Variable("Last subindex", 0x1002, 0))
+        array = od.ODArray("Test Array", 0x1002)
+        array.add_member(od.ODVariable("Last subindex", 0x1002, 0))
         test_od.add_object(array)
         self.assertEqual(test_od["Test Array"], array)
         self.assertEqual(test_od[0x1002], array)
@@ -126,12 +126,12 @@ class TestObjectDictionary(unittest.TestCase):
 class TestArray(unittest.TestCase):
 
     def test_subindexes(self):
-        array = od.Array("Test Array", 0x1000)
-        last_subindex = od.Variable("Last subindex", 0x1000, 0)
+        array = od.ODArray("Test Array", 0x1000)
+        last_subindex = od.ODVariable("Last subindex", 0x1000, 0)
         last_subindex.data_type = od.UNSIGNED8
         array.add_member(last_subindex)
-        array.add_member(od.Variable("Test Variable", 0x1000, 1))
-        array.add_member(od.Variable("Test Variable 2", 0x1000, 2))
+        array.add_member(od.ODVariable("Test Variable", 0x1000, 1))
+        array.add_member(od.ODVariable("Test Variable 2", 0x1000, 2))
         self.assertEqual(array[0].name, "Last subindex")
         self.assertEqual(array[1].name, "Test Variable")
         self.assertEqual(array[2].name, "Test Variable 2")


### PR DESCRIPTION
To create better distinction between the different Variable, Record and Array types used for different purposes. Helps development, as IDE/linters often only display base name of class. Discussed in issue #363 

Unittests pass and generated sphinx documents have been skimmed over.