### PR TITLE
Change attribute getters and setters into methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,11 +115,11 @@ The :code:`n` is the PDO index (normally 1 to 4). The second form of access is f
     # network.connect(bustype='nican', channel='CAN0', bitrate=250000)
 
     # Read a variable using SDO
-    device_name = node.sdo['Manufacturer device name'].raw
-    vendor_id = node.sdo[0x1018][1].raw
+    device_name = node.sdo['Manufacturer device name'].get_raw()
+    vendor_id = node.sdo[0x1018][1].get_raw()
 
     # Write a variable using SDO
-    node.sdo['Producer heartbeat time'].raw = 1000
+    node.sdo['Producer heartbeat time'].set_raw(1000)
 
     # Read PDO configuration from node
     node.tpdo.read()
@@ -139,12 +139,12 @@ The :code:`n` is the PDO index (normally 1 to 4). The second form of access is f
     network.sync.start(0.1)
 
     # Change state to operational (NMT start)
-    node.nmt.state = 'OPERATIONAL'
+    node.nmt.set_state('OPERATIONAL')
 
     # Read a value from TPDO[1]
     node.tpdo[1].wait_for_reception()
-    speed = node.tpdo[1]['Velocity actual value'].phys
-    val = node.tpdo['Some group.Some subindex'].raw
+    speed = node.tpdo[1]['Velocity actual value'].get_phys()
+    val = node.tpdo['Some group.Some subindex'].get_raw()
 
     # Disconnect from CAN bus
     network.sync.stop()

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -75,6 +75,9 @@ class NmtBase(object):
 
     @property
     def state(self) -> str:
+        return self.get_state()
+
+    def get_state(self) -> str:
         """Attribute to get or set node's state as a string.
 
         Can be one of:
@@ -95,6 +98,10 @@ class NmtBase(object):
 
     @state.setter
     def state(self, new_state: str):
+        logger.warning("Accessing NmtBase.state setter is deprecated, use set_state()")
+        self.set_state(new_state)
+
+    def set_state(self, new_state: str):
         if new_state in NMT_COMMANDS:
             code = NMT_COMMANDS[new_state]
         else:
@@ -150,7 +157,7 @@ class NmtMaster(NmtBase):
             self.state_update.wait(timeout)
         if self._state_received is None:
             raise NmtError("No boot-up or heartbeat received")
-        return self.state
+        return self.get_state()
 
     def wait_for_bootup(self, timeout: float = 10) -> None:
         """Wait until a boot-up message is received."""
@@ -220,7 +227,7 @@ class NmtSlave(NmtBase):
         # The heartbeat service should start on the transition
         # between INITIALIZING and PRE-OPERATIONAL state
         if old_state == 0 and self._state == 127:
-            heartbeat_time_ms = self._local_node.sdo[0x1017].raw
+            heartbeat_time_ms = self._local_node.sdo[0x1017].get_raw()
             self.start_heartbeat(heartbeat_time_ms)
         else:
             self.update_heartbeat()

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -131,9 +131,9 @@ class RemoteNode(BaseNode):
                     subindex=subindex,
                     name=name,
                     value=value)))
-                self.sdo[index][subindex].raw = value
+                self.sdo[index][subindex].set_raw(value)
             else:
-                self.sdo[index].raw = value
+                self.sdo[index].set_raw(value)
                 logger.info(str('SDO [{index:#06x}]: {name}: {value:#06x}'.format(
                     index=index,
                     name=name,

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -315,41 +315,41 @@ class Map(object):
 
     def read(self) -> None:
         """Read PDO configuration for this map using SDO."""
-        cob_id = self.com_record[1].raw
+        cob_id = self.com_record[1].get_raw()
         self.cob_id = cob_id & 0x1FFFFFFF
         logger.info("COB-ID is 0x%X", self.cob_id)
         self.enabled = cob_id & PDO_NOT_VALID == 0
         logger.info("PDO is %s", "enabled" if self.enabled else "disabled")
         self.rtr_allowed = cob_id & RTR_NOT_ALLOWED == 0
         logger.info("RTR is %s", "allowed" if self.rtr_allowed else "not allowed")
-        self.trans_type = self.com_record[2].raw
+        self.trans_type = self.com_record[2].get_raw()
         logger.info("Transmission type is %d", self.trans_type)
         if self.trans_type >= 254:
             try:
-                self.inhibit_time = self.com_record[3].raw
+                self.inhibit_time = self.com_record[3].get_raw()
             except (KeyError, SdoAbortedError) as e:
                 logger.info("Could not read inhibit time (%s)", e)
             else:
                 logger.info("Inhibit time is set to %d ms", self.inhibit_time)
 
             try:
-                self.event_timer = self.com_record[5].raw
+                self.event_timer = self.com_record[5].get_raw()
             except (KeyError, SdoAbortedError) as e:
                 logger.info("Could not read event timer (%s)", e)
             else:
                 logger.info("Event timer is set to %d ms", self.event_timer)
 
             try:
-                self.sync_start_value = self.com_record[6].raw
+                self.sync_start_value = self.com_record[6].get_raw()
             except (KeyError, SdoAbortedError) as e:
                 logger.info("Could not read SYNC start value (%s)", e)
             else:
                 logger.info("SYNC start value is set to %d ms", self.sync_start_value)
 
         self.clear()
-        nof_entries = self.map_array[0].raw
+        nof_entries = self.map_array[0].get_raw()
         for subindex in range(1, nof_entries + 1):
-            value = self.map_array[subindex].raw
+            value = self.map_array[subindex].get_raw()
             index = value >> 16
             subindex = (value >> 8) & 0xFF
             size = value & 0xFF
@@ -366,44 +366,44 @@ class Map(object):
         """Save PDO configuration for this map using SDO."""
         logger.info("Setting COB-ID 0x%X and temporarily disabling PDO",
                     self.cob_id)
-        self.com_record[1].raw = self.cob_id | PDO_NOT_VALID | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0)
+        self.com_record[1].set_raw(self.cob_id | PDO_NOT_VALID | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0))
         if self.trans_type is not None:
             logger.info("Setting transmission type to %d", self.trans_type)
-            self.com_record[2].raw = self.trans_type
+            self.com_record[2].set_raw(self.trans_type)
         if self.inhibit_time is not None:
             logger.info("Setting inhibit time to %d us", (self.inhibit_time * 100))
-            self.com_record[3].raw = self.inhibit_time
+            self.com_record[3].set_raw(self.inhibit_time)
         if self.event_timer is not None:
             logger.info("Setting event timer to %d ms", self.event_timer)
-            self.com_record[5].raw = self.event_timer
+            self.com_record[5].set_raw(self.event_timer)
         if self.sync_start_value is not None:
             logger.info("Setting SYNC start value to %d", self.sync_start_value)
-            self.com_record[6].raw = self.sync_start_value
+            self.com_record[6].set_raw(self.sync_start_value)
 
         if self.map is not None:
             try:
-                self.map_array[0].raw = 0
+                self.map_array[0].set_raw(0)
             except SdoAbortedError:
                 # WORKAROUND for broken implementations: If the array has a
                 # fixed number of entries (count not writable), generate dummy
                 # mappings for an invalid object 0x0000:00 to overwrite any
                 # excess entries with all-zeros.
-                self._fill_map(self.map_array[0].raw)
+                self._fill_map(self.map_array[0].get_raw())
             subindex = 1
             for var in self.map:
                 logger.info("Writing %s (0x%X:%d, %d bits) to PDO map",
                             var.name, var.index, var.subindex, var.length)
                 if hasattr(self.pdo_node.node, "curtis_hack") and self.pdo_node.node.curtis_hack:  # Curtis HACK: mixed up field order
-                    self.map_array[subindex].raw = (var.index |
-                                                    var.subindex << 16 |
-                                                    var.length << 24)
+                    self.map_array[subindex].set_raw(var.index |
+                                                     var.subindex << 16 |
+                                                     var.length << 24)
                 else:
-                    self.map_array[subindex].raw = (var.index << 16 |
-                                                    var.subindex << 8 |
-                                                    var.length)
+                    self.map_array[subindex].set_raw(var.index << 16 |
+                                                     var.subindex << 8 |
+                                                     var.length)
                 subindex += 1
             try:
-                self.map_array[0].raw = len(self.map)
+                self.map_array[0].set_raw(len(self.map))
             except SdoAbortedError as e:
                 # WORKAROUND for broken implementations: If the array
                 # number-of-entries parameter is not writable, we have already
@@ -415,7 +415,7 @@ class Map(object):
             self._update_data_size()
 
         if self.enabled:
-            self.com_record[1].raw = self.cob_id | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0)
+            self.com_record[1].set_raw(self.cob_id | (RTR_NOT_ALLOWED if not self.rtr_allowed else 0x0))
             self.subscribe()
 
     def subscribe(self) -> None:

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -111,7 +111,7 @@ class Array(Mapping):
         return iter(range(1, len(self) + 1))
 
     def __len__(self) -> int:
-        return self[0].raw
+        return self[0].get_raw()
 
     def __contains__(self, subindex: int) -> bool:
         return 0 <= subindex <= len(self)

--- a/canopen/variable.py
+++ b/canopen/variable.py
@@ -26,6 +26,7 @@ class Variable(object):
         self.subindex = od.subindex
 
     def get_data(self) -> bytes:
+        """Byte representation of the object as :class:`bytes`."""
         raise NotImplementedError("Variable is not readable")
 
     def set_data(self, data: bytes):
@@ -33,15 +34,20 @@ class Variable(object):
 
     @property
     def data(self) -> bytes:
-        """Byte representation of the object as :class:`bytes`."""
+        logger.warning("Accessing Variable.data property is deprecated, use get_data()")
         return self.get_data()
 
     @data.setter
     def data(self, data: bytes):
+        logger.warning("Accessing Variable.data setter is deprecated, use set_data()")
         self.set_data(data)
 
     @property
     def raw(self) -> Union[int, bool, float, str, bytes]:
+        logger.warning("Accessing Variable.raw property is deprecated, use get_raw()")
+        return self.get_raw()
+
+    def get_raw(self) -> Union[int, bool, float, str, bytes]:
         """Raw representation of the object.
 
         This table lists the translations between object dictionary data types
@@ -72,7 +78,7 @@ class Variable(object):
         Data types that this library does not handle yet must be read and
         written as :class:`bytes`.
         """
-        value = self.od.decode_raw(self.data)
+        value = self.od.decode_raw(self.get_data())
         text = "Value of %s (0x%X:%d) is %r" % (
             self.name, self.index,
             self.subindex, value)
@@ -83,41 +89,65 @@ class Variable(object):
 
     @raw.setter
     def raw(self, value: Union[int, bool, float, str, bytes]):
+        logger.warning("Accessing Variable.raw setter is deprecated, use set_raw()")
+        self.set_raw(value)
+
+    def set_raw(self, value: Union[int, bool, float, str, bytes]):
         logger.debug("Writing %s (0x%X:%d) = %r",
                      self.name, self.index,
                      self.subindex, value)
-        self.data = self.od.encode_raw(value)
+        self.set_data(self.od.encode_raw(value))
 
     @property
     def phys(self) -> Union[int, bool, float, str, bytes]:
+        logger.warning("Accessing Variable.phys attribute is deprecated, use get_phys()")
+        return self.get_phys()
+
+    def get_phys(self) -> Union[int, bool, float, str, bytes]:
         """Physical value scaled with some factor (defaults to 1).
 
         On object dictionaries that support specifying a factor, this can be
         either a :class:`float` or an :class:`int`.
         Non integers will be passed as is.
         """
-        value = self.od.decode_phys(self.raw)
+        value = self.od.decode_phys(self.get_raw())
         if self.od.unit:
             logger.debug("Physical value is %s %s", value, self.od.unit)
         return value
 
     @phys.setter
     def phys(self, value: Union[int, bool, float, str, bytes]):
-        self.raw = self.od.encode_phys(value)
+        logger.warning("Accessing Variable.phys setter is deprecated, use set_phys()")
+        self.set_phys(value)
+
+    def set_phys(self, value: Union[int, bool, float, str, bytes]):
+        self.set_raw(self.od.encode_phys(value))
 
     @property
     def desc(self) -> str:
+        logger.warning("Accessing Variable.desc attribute is deprecated, use get_desc()")
+        return self.get_desc()
+
+    def get_desc(self) -> str:
         """Converts to and from a description of the value as a string."""
-        value = self.od.decode_desc(self.raw)
+        value = self.od.decode_desc(self.get_raw())
         logger.debug("Description is '%s'", value)
         return value
 
     @desc.setter
     def desc(self, desc: str):
-        self.raw = self.od.encode_desc(desc)
+        logger.warning("Accessing Variable.desc setter is deprecated, use set_desc()")
+        self.set_desc(desc)
+
+    def set_desc(self, desc: str):
+        self.set_raw(self.od.encode_desc(desc))
 
     @property
     def bits(self) -> "Bits":
+        logger.warning("Accessing Variable.bits attribute is deprecated, use get_bits()")
+        return self.get_bits()
+
+    def get_bits(self) -> "Bits":
         """Access bits using integers, slices, or bit descriptions."""
         return Bits(self)
 
@@ -136,11 +166,11 @@ class Variable(object):
             The value of the variable.
         """
         if fmt == "raw":
-            return self.raw
+            return self.get_raw()
         elif fmt == "phys":
-            return self.phys
+            return self.get_phys()
         elif fmt == "desc":
-            return self.desc
+            return self.get_desc()
 
     def write(
         self, value: Union[int, bool, float, str, bytes], fmt: str = "raw"
@@ -156,11 +186,11 @@ class Variable(object):
              - 'desc'
         """
         if fmt == "raw":
-            self.raw = value
+            self.set_raw(value)
         elif fmt == "phys":
-            self.phys = value
+            self.set_phys(value)
         elif fmt == "desc":
-            self.desc = value
+            self.set_desc(value)
 
 
 class Bits(Mapping):
@@ -194,7 +224,7 @@ class Bits(Mapping):
         return len(self.variable.od.bit_definitions)
 
     def read(self):
-        self.raw = self.variable.raw
+        self.raw = self.variable.get_raw()
 
     def write(self):
-        self.variable.raw = self.raw
+        self.variable.set_raw(self.raw)

--- a/doc/nmt.rst
+++ b/doc/nmt.rst
@@ -27,25 +27,24 @@ Examples
 --------
 
 Access the NMT functionality using the :attr:`canopen.Node.nmt` attribute.
-Changing state can be done using the :attr:`~canopen.nmt.NmtMaster.state`
-attribute::
+Changing state can be done using the :meth:`~canopen.nmt.NmtMaster.set_state()`
+method::
 
-    node.nmt.state = 'OPERATIONAL'
+    node.nmt.set_state('OPERATIONAL')
     # Same as sending NMT start
     node.nmt.send_command(0x1)
 
 You can also change state of all nodes simulaneously as a broadcast message::
 
-    network.nmt.state = 'OPERATIONAL'
+    network.nmt.set_state('OPERATIONAL')
 
-If the node transmits heartbeat messages, the
-:attr:`~canopen.nmt.NmtMaster.state` attribute gets automatically updated with
-current state::
+If the node transmits heartbeat messages, the state can be read with
+:meth:`~canopen.nmt.NmtMaster.get_state()`::
 
     # Send NMT start to all nodes
     network.send_message(0x0, [0x1, 0])
     node.nmt.wait_for_heartbeat()
-    assert node.nmt.state == 'OPERATIONAL'
+    assert node.nmt.get_state() == 'OPERATIONAL'
 
 
 API

--- a/doc/pdo.rst
+++ b/doc/pdo.rst
@@ -51,20 +51,20 @@ starts at 1, not 0)::
     node.rpdo[4].enabled = True
 
     # Save new configuration (node must be in pre-operational)
-    node.nmt.state = 'PRE-OPERATIONAL'
+    node.nmt.set_state('PRE-OPERATIONAL')
     node.tpdo.save()
     node.rpdo.save()
 
     # Start RPDO4 with an interval of 100 ms
-    node.rpdo[4]['Application Commands.Command Speed'].phys = 1000
+    node.rpdo[4]['Application Commands.Command Speed'].set_phys(1000)
     node.rpdo[4].start(0.1)
-    node.nmt.state = 'OPERATIONAL'
+    node.nmt.set_state('OPERATIONAL')
 
     # Read 50 values of speed and save to a file
     with open('output.txt', 'w') as f:
         for i in range(50):
             node.tpdo[4].wait_for_reception()
-            speed = node.tpdo['Application Status.Actual Speed'].phys
+            speed = node.tpdo['Application Status.Actual Speed'].get_phys()
             f.write('%s\n' % speed)
 
     # Using a callback to asynchronously receive values
@@ -72,7 +72,7 @@ starts at 1, not 0)::
     def print_speed(message):
         print('%s received' % message.name)
         for var in message:
-            print('%s = %d' % (var.name, var.raw))
+            print('%s = %d' % (var.name, var.get_raw()))
 
     node.tpdo[4].add_callback(print_speed)
     time.sleep(5)

--- a/doc/profiles.rst
+++ b/doc/profiles.rst
@@ -48,25 +48,25 @@ That works only in the 'OPERATIONAL' or 'PRE-OPERATIONAL' states of the
 Write Controlword and read Statusword::
 
     # command to go to 'READY TO SWITCH ON' from 'NOT READY TO SWITCH ON' or 'SWITCHED ON'
-    some_node.sdo[0x6040].raw = 0x06
+    some_node.sdo[0x6040].set_raw(0x06)
 
     # Read the state of the Statusword
-    some_node.sdo[0x6041].raw
+    some_node.sdo[0x6041].get_raw()
 
 During operation the state can change to states which cannot be commanded by the
 Controlword, for example a 'FAULT' state.  Therefore the :class:`BaseNode402`
 class (in similarity to :class:`NmtMaster`) automatically monitors state changes
 of the Statusword which is sent by TPDO.  The available callback on that TPDO
 will then extract the information and mirror the state change in the
-:attr:`BaseNode402.state` attribute.
+:meth:`BaseNode402.get_state()` method.
 
 Similar to the :class:`NmtMaster` class, the states of the :class:`BaseNode402`
-class :attr:`.state` attribute can be read and set (command) by a string::
+class can be read and set (command) by a string::
 
     # command a state (an SDO message will be called)
-    some_node.state = 'SWITCHED ON'
+    some_node.set_state('SWITCHED ON')
     # read the current state
-    some_node.state
+    some_node.get_state()
 
 Available states:
 

--- a/doc/sdo.rst
+++ b/doc/sdo.rst
@@ -44,23 +44,24 @@ The code below only creates objects, no messages are sent or received yet::
     # Arrays
     error_log = node.sdo[0x1003]
 
-To actually read or write the variables, use the ``.raw``, ``.phys``, ``.desc``,
-or ``.bits`` attributes::
+To actually read or write the variables, use the
+``.get_raw()``, ``.set_raw()``, ``.get_phys()``, ``.set_phys()``,
+``.get_desc()``, ``.set_desc()``, ``.get_bits()`` methods::
 
-    print("The device type is 0x%X" % device_type.raw)
+    print("The device type is 0x%X" % device_type.get_raw())
 
     # Using value descriptions instead of integers (if supported by OD)
-    control_mode.desc = 'Speed Mode'
+    control_mode.set_desc('Speed Mode')
 
     # Set individual bit
-    command_all.bits[3] = 1
+    command_all.get_bits()[3] = 1
 
     # Read and write physical values scaled by a factor (if supported by OD)
-    print("The actual speed is %f rpm" % actual_speed.phys)
+    print("The actual speed is %f rpm" % actual_speed.get_phys())
 
     # Iterate over arrays or records
     for error in error_log.values():
-        print("Error 0x%X was found in the log" % error.raw)
+        print("Error 0x%X was found in the log" % error.get_raw())
 
 It is also possible to read and write to variables that are not in the Object
 Dictionary, but only using raw bytes::

--- a/examples/simple_ds402_node.py
+++ b/examples/simple_ds402_node.py
@@ -22,48 +22,48 @@ try:
     # node = network[34]
 
     # Reset network
-    node.nmt.state = 'RESET COMMUNICATION'
-    #node.nmt.state = 'RESET'
+    node.nmt.set_state('RESET COMMUNICATION')
+    #node.nmt.set_state('RESET')
     node.nmt.wait_for_bootup(15)
 
-    print('node state 1) = {0}'.format(node.nmt.state))
+    print('node state 1) = {0}'.format(node.nmt.get_state()))
 
     # Iterate over arrays or records
     error_log = node.sdo[0x1003]
     for error in error_log.values():
-        print("Error {0} was found in the log".format(error.raw))
+        print("Error {0} was found in the log".format(error.get_raw()))
 
     for node_id in network:
         print(network[node_id])
 
-    print('node state 2) = {0}'.format(node.nmt.state))
+    print('node state 2) = {0}'.format(node.nmt.get_state()))
 
     # Read a variable using SDO
 
-    node.sdo[0x1006].raw = 1
-    node.sdo[0x100c].raw = 100
-    node.sdo[0x100d].raw = 3
-    node.sdo[0x1014].raw = 163
-    node.sdo[0x1003][0].raw = 0
+    node.sdo[0x1006].set_raw(1)
+    node.sdo[0x100c].set_raw(100)
+    node.sdo[0x100d].set_raw(3)
+    node.sdo[0x1014].set_raw(163)
+    node.sdo[0x1003][0].set_raw(0)
 
     # Transmit SYNC every 100 ms
     network.sync.start(0.1)
 
     node.load_configuration()
 
-    print('node state 3) = {0}'.format(node.nmt.state))
+    print('node state 3) = {0}'.format(node.nmt.get_state()))
 
     node.setup_402_state_machine()
 
-    device_name = node.sdo[0x1008].raw
-    vendor_id = node.sdo[0x1018][1].raw
+    device_name = node.sdo[0x1008].get_raw()
+    vendor_id = node.sdo[0x1018][1].get_raw()
 
     print(device_name)
     print(vendor_id)
 
-    node.state = 'SWITCH ON DISABLED'
+    node.set_state('SWITCH ON DISABLED')
 
-    print('node state 4) = {0}'.format(node.nmt.state))
+    print('node state 4) = {0}'.format(node.nmt.get_state()))
 
     # Read PDO configuration from node
     node.tpdo.read()
@@ -80,13 +80,13 @@ try:
     # publish the a value to the control word (in this case reset the fault at the motors)
 
     node.rpdo.read()
-    node.rpdo[1]['Controlword'].raw = 0x80
+    node.rpdo[1]['Controlword'].set_raw(0x80)
     node.rpdo[1].transmit()
-    node.rpdo[1]['Controlword'].raw = 0x81
+    node.rpdo[1]['Controlword'].set_raw(0x81)
     node.rpdo[1].transmit()
 
-    node.state = 'READY TO SWITCH ON'
-    node.state = 'SWITCHED ON'
+    node.set_state('READY TO SWITCH ON')
+    node.set_state('SWITCHED ON')
 
     node.rpdo.export('database.dbc')
 
@@ -95,27 +95,27 @@ try:
     print('Node booted up')
 
     timeout = time.time() + 15
-    node.state = 'READY TO SWITCH ON'
-    while node.state != 'READY TO SWITCH ON':
+    node.set_state('READY TO SWITCH ON')
+    while node.get_state() != 'READY TO SWITCH ON':
         if time.time() > timeout:
             raise Exception('Timeout when trying to change state')
         time.sleep(0.001)
 
     timeout = time.time() + 15
-    node.state = 'SWITCHED ON'
-    while node.state != 'SWITCHED ON':
+    node.set_state('SWITCHED ON')
+    while node.get_state() != 'SWITCHED ON':
         if time.time() > timeout:
             raise Exception('Timeout when trying to change state')
         time.sleep(0.001)
 
     timeout = time.time() + 15
-    node.state = 'OPERATION ENABLED'
-    while node.state != 'OPERATION ENABLED':
+    node.set_state('OPERATION ENABLED')
+    while node.get_state() != 'OPERATION ENABLED':
         if time.time() > timeout:
             raise Exception('Timeout when trying to change state')
         time.sleep(0.001)
 
-    print('Node Status {0}'.format(node.powerstate_402.state))
+    print('Node Status {0}'.format(node.powerstate_402.get_state()))
 
     # -----------------------------------------------------------------------------------------
     node.nmt.start_node_guarding(0.01)
@@ -127,10 +127,10 @@ try:
 
         # Read a value from TxPDO1
         node.tpdo[1].wait_for_reception()
-        speed = node.tpdo[1]['Velocity actual value'].phys
+        speed = node.tpdo[1]['Velocity actual value'].get_phys()
 
         # Read the state of the Statusword
-        statusword = node.sdo[0x6041].raw
+        statusword = node.sdo[0x6041].get_raw()
 
         print('statusword: {0}'.format(statusword))
         print('VEL: {0}'.format(speed))
@@ -151,7 +151,7 @@ finally:
 
         for node_id in network:
             node = network[node_id]
-            node.nmt.state = 'PRE-OPERATIONAL'
+            node.nmt.set_state('PRE-OPERATIONAL')
             node.nmt.stop_node_guarding()
         network.sync.stop()
         network.disconnect()

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -28,7 +28,7 @@ class TestNetwork(unittest.TestCase):
         self.network.notify(0x82, b'\x01\x20\x02\x00\x01\x02\x03\x04', 1473418396.0)
         self.assertEqual(len(node.emcy.active), 1)
         self.network.notify(0x702, b'\x05', 1473418396.0)
-        self.assertEqual(node.nmt.state, 'OPERATIONAL')
+        self.assertEqual(node.nmt.get_state(), 'OPERATIONAL')
         self.assertListEqual(self.network.scanner.nodes, [2])
 
     def test_send(self):

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -18,42 +18,42 @@ class TestPDO(unittest.TestCase):
         map.add_variable('BOOLEAN value 2', length=1)  # 0x2006
 
         # Write some values
-        map['INTEGER16 value'].raw = -3
-        map['UNSIGNED8 value'].raw = 0xf
-        map['INTEGER8 value'].raw = -2
-        map['INTEGER32 value'].raw = 0x01020304
-        map['BOOLEAN value'].raw = False
-        map['BOOLEAN value 2'].raw = True
+        map['INTEGER16 value'].set_raw(-3)
+        map['UNSIGNED8 value'].set_raw(0xf)
+        map['INTEGER8 value'].set_raw(-2)
+        map['INTEGER32 value'].set_raw(0x01020304)
+        map['BOOLEAN value'].set_raw(False)
+        map['BOOLEAN value 2'].set_raw(True)
 
         # Check expected data
         self.assertEqual(map.data, b'\xfd\xff\xef\x04\x03\x02\x01\x02')
 
         # Read values from data
-        self.assertEqual(map['INTEGER16 value'].raw, -3)
-        self.assertEqual(map['UNSIGNED8 value'].raw, 0xf)
-        self.assertEqual(map['INTEGER8 value'].raw, -2)
-        self.assertEqual(map['INTEGER32 value'].raw, 0x01020304)
-        self.assertEqual(map['BOOLEAN value'].raw, False)
-        self.assertEqual(map['BOOLEAN value 2'].raw, True)
+        self.assertEqual(map['INTEGER16 value'].get_raw(), -3)
+        self.assertEqual(map['UNSIGNED8 value'].get_raw(), 0xf)
+        self.assertEqual(map['INTEGER8 value'].get_raw(), -2)
+        self.assertEqual(map['INTEGER32 value'].get_raw(), 0x01020304)
+        self.assertEqual(map['BOOLEAN value'].get_raw(), False)
+        self.assertEqual(map['BOOLEAN value 2'].get_raw(), True)
 
-        self.assertEqual(node.tpdo[1]['INTEGER16 value'].raw, -3)
-        self.assertEqual(node.tpdo[1]['UNSIGNED8 value'].raw, 0xf)
-        self.assertEqual(node.tpdo[1]['INTEGER8 value'].raw, -2)
-        self.assertEqual(node.tpdo[1]['INTEGER32 value'].raw, 0x01020304)
-        self.assertEqual(node.tpdo['INTEGER32 value'].raw, 0x01020304)
-        self.assertEqual(node.tpdo[1]['BOOLEAN value'].raw, False)
-        self.assertEqual(node.tpdo[1]['BOOLEAN value 2'].raw, True)
+        self.assertEqual(node.tpdo[1]['INTEGER16 value'].get_raw(), -3)
+        self.assertEqual(node.tpdo[1]['UNSIGNED8 value'].get_raw(), 0xf)
+        self.assertEqual(node.tpdo[1]['INTEGER8 value'].get_raw(), -2)
+        self.assertEqual(node.tpdo[1]['INTEGER32 value'].get_raw(), 0x01020304)
+        self.assertEqual(node.tpdo['INTEGER32 value'].get_raw(), 0x01020304)
+        self.assertEqual(node.tpdo[1]['BOOLEAN value'].get_raw(), False)
+        self.assertEqual(node.tpdo[1]['BOOLEAN value 2'].get_raw(), True)
 
         # Test different types of access
-        self.assertEqual(node.pdo[0x1600]['INTEGER16 value'].raw, -3)
-        self.assertEqual(node.pdo['INTEGER16 value'].raw, -3)
-        self.assertEqual(node.pdo.tx[1]['INTEGER16 value'].raw, -3)
-        self.assertEqual(node.pdo[0x2001].raw, -3)
-        self.assertEqual(node.tpdo[0x2001].raw, -3)
-        self.assertEqual(node.pdo[0x2002].raw, 0xf)
-        self.assertEqual(node.pdo['0x2002'].raw, 0xf)
-        self.assertEqual(node.tpdo[0x2002].raw, 0xf)
-        self.assertEqual(node.pdo[0x1600][0x2002].raw, 0xf)
+        self.assertEqual(node.pdo[0x1600]['INTEGER16 value'].get_raw(), -3)
+        self.assertEqual(node.pdo['INTEGER16 value'].get_raw(), -3)
+        self.assertEqual(node.pdo.tx[1]['INTEGER16 value'].get_raw(), -3)
+        self.assertEqual(node.pdo[0x2001].get_raw(), -3)
+        self.assertEqual(node.tpdo[0x2001].get_raw(), -3)
+        self.assertEqual(node.pdo[0x2002].get_raw(), 0xf)
+        self.assertEqual(node.pdo['0x2002'].get_raw(), 0xf)
+        self.assertEqual(node.tpdo[0x2002].get_raw(), 0xf)
+        self.assertEqual(node.pdo[0x1600][0x2002].get_raw(), 0xf)
 
 
 if __name__ == "__main__":

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -42,7 +42,7 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x40\x18\x10\x01\x00\x00\x00\x00'),
             (RX, b'\x43\x18\x10\x01\x04\x00\x00\x00')
         ]
-        vendor_id = self.network[2].sdo[0x1018][1].raw
+        vendor_id = self.network[2].sdo[0x1018][1].get_raw()
         self.assertEqual(vendor_id, 4)
 
         # UNSIGNED8 without padded data part (see issue #5)
@@ -50,7 +50,7 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x40\x00\x14\x02\x00\x00\x00\x00'),
             (RX, b'\x4f\x00\x14\x02\xfe')
         ]
-        trans_type = self.network[2].sdo[0x1400]['Transmission type RPDO 1'].raw
+        trans_type = self.network[2].sdo[0x1400]['Transmission type RPDO 1'].get_raw()
         self.assertEqual(trans_type, 254)
 
     def test_size_not_specified(self):
@@ -67,7 +67,7 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x2b\x17\x10\x00\xa0\x0f\x00\x00'),
             (RX, b'\x60\x17\x10\x00\x00\x00\x00\x00')
         ]
-        self.network[2].sdo[0x1017].raw = 4000
+        self.network[2].sdo[0x1017].set_raw(4000)
 
     def test_segmented_upload(self):
         self.data = [
@@ -82,7 +82,7 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x70\x00\x00\x00\x00\x00\x00\x00'),
             (RX, b'\x15\x69\x6E\x73\x20\x21\x00\x00')
         ]
-        device_name = self.network[2].sdo[0x1008].raw
+        device_name = self.network[2].sdo[0x1008].get_raw()
         self.assertEqual(device_name, "Tiny Node - Mega Domains !")
 
     def test_segmented_download(self):
@@ -94,7 +94,7 @@ class TestSDO(unittest.TestCase):
             (TX, b'\x13\x73\x74\x72\x69\x6e\x67\x00'),
             (RX, b'\x30\x00\x20\x00\x00\x00\x00\x00')
         ]
-        self.network[2].sdo['Writable string'].raw = 'A long string'
+        self.network[2].sdo['Writable string'].set_raw('A long string')
 
     def test_block_download(self):
         self.data = [
@@ -159,7 +159,7 @@ class TestSDO(unittest.TestCase):
             (RX, b'\x80\x18\x10\x01\x11\x00\x09\x06')
         ]
         with self.assertRaises(canopen.SdoAbortedError) as cm:
-            _ = self.network[2].sdo[0x1018][1].raw
+            _ = self.network[2].sdo[0x1018][1].get_raw()
         self.assertEqual(cm.exception.code, 0x06090011)
 
     def test_add_sdo_channel(self):


### PR DESCRIPTION
This PR adds access methods, `get_*` and `set_*` where attribute getter and setters are used. The old getters and setters are kept intact and working, but using it prints a warning in the log if used.

The motivation for the proposals are:
* IO blocking operations are opaque with getters/setters. That `var.raw` generate blocking IO is unexpected and hard to track (and somewhat unconventional)
* Getter and setters cannot be used when using async. Having dedicated access methods allows similar usage of API between the regular blocking API and the async implementation

Having getters and setters have some upsides too:
* Getters and setters are very compact: `var = param.raw` and `param.raw = 42` is neat.
* This is the established API in canopen

The intention by adding this PR is to try it on for size. @acolomb expressed skepticism for it  in #355, while @christiansandberg expressed interest in #271. Perhaps there is a middle ground to be gained?