### PR TITLE
Feature/eds parse factor and description

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -392,11 +392,11 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         if getattr(var, 'max', None) is not None:
             eds.set(section, "HighLimit", var.max)
 
-        if getattr(var, 'description', '') is not '':
+        if getattr(var, 'description', '') != '':
             eds.set(section, "Description", var.description)
-        if getattr(var, 'factor', 1) is not 1:
+        if getattr(var, 'factor', 1) != 1:
             eds.set(section, "Factor", var.factor)
-        if getattr(var, 'unit', '') is not '':
+        if getattr(var, 'unit', '') != '':
             eds.set(section, "Unit", var.unit)
 
     def export_record(var, eds):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -392,6 +392,13 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         if getattr(var, 'max', None) is not None:
             eds.set(section, "HighLimit", var.max)
 
+        if getattr(var, 'description', None) is not None:
+            eds.set(section, "Description", var.description)
+        if getattr(var, 'factor', None) is not None:
+            eds.set(section, "Factor", var.factor)
+        if getattr(var, 'unit', None) is not None:
+            eds.set(section, "Unit", var.unit)
+
     def export_record(var, eds):
         section = "%04X" % var.index
         export_common(var, eds, section)

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -309,6 +309,16 @@ def build_variable(eds, section, node_id, index, subindex=0):
             var.value = _convert_variable(node_id, var.data_type, eds.get(section, "ParameterValue"))
         except ValueError:
             pass
+    if eds.has_option(section, "Factor"):
+        try:
+            var.factor = float(eds.get(section, "Factor"), 1)
+        except ValueError:
+            pass
+    if eds.has_option(section, "Description"):
+        try:
+            var.description = eds.get(section, "Description")
+        except ValueError:
+            pass
     return var
 
 

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -309,9 +309,10 @@ def build_variable(eds, section, node_id, index, subindex=0):
             var.value = _convert_variable(node_id, var.data_type, eds.get(section, "ParameterValue"))
         except ValueError:
             pass
+    # Factor and Description are not standard according to the CANopen specifications, but they are implemented in the python canopen package, so we can at least try to use them
     if eds.has_option(section, "Factor"):
         try:
-            var.factor = float(eds.get(section, "Factor"), 1)
+            var.factor = float(eds.get(section, "Factor"))
         except ValueError:
             pass
     if eds.has_option(section, "Description"):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -392,11 +392,11 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
         if getattr(var, 'max', None) is not None:
             eds.set(section, "HighLimit", var.max)
 
-        if getattr(var, 'description', None) is not None:
+        if getattr(var, 'description', '') is not '':
             eds.set(section, "Description", var.description)
-        if getattr(var, 'factor', None) is not None:
+        if getattr(var, 'factor', 1) is not 1:
             eds.set(section, "Factor", var.factor)
-        if getattr(var, 'unit', None) is not None:
+        if getattr(var, 'unit', '') is not '':
             eds.set(section, "Unit", var.unit)
 
     def export_record(var, eds):

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -309,7 +309,7 @@ def build_variable(eds, section, node_id, index, subindex=0):
             var.value = _convert_variable(node_id, var.data_type, eds.get(section, "ParameterValue"))
         except ValueError:
             pass
-    # Factor and Description are not standard according to the CANopen specifications, but they are implemented in the python canopen package, so we can at least try to use them
+    # Factor, Description and Unit are not standard according to the CANopen specifications, but they are implemented in the python canopen package, so we can at least try to use them
     if eds.has_option(section, "Factor"):
         try:
             var.factor = float(eds.get(section, "Factor"))
@@ -318,6 +318,11 @@ def build_variable(eds, section, node_id, index, subindex=0):
     if eds.has_option(section, "Description"):
         try:
             var.description = eds.get(section, "Description")
+        except ValueError:
+            pass
+    if eds.has_option(section, "Unit"):
+        try:
+            var.unit = eds.get(section, "Unit")
         except ValueError:
             pass
     return var

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -961,6 +961,7 @@ AccessType=ro
 PDOMapping=0x0
 Factor=0.1
 Description=This is the a test description
+Unit=mV
 
 [3050sub2]
 ParameterName=Error Factor and No Description
@@ -970,3 +971,4 @@ AccessType=ro
 PDOMapping=0x0
 Factor=ERROR
 Description=
+Unit=

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -938,3 +938,35 @@ AccessType=rw
 HighLimit=0x000000000000000A
 LowLimit=0x8000000000000009
 PDOMapping=0
+
+
+[3050]
+ParameterName=EDS file extensions
+SubNumber=0x7
+ObjectType=0x9
+
+[3050sub0]
+ParameterName=Highest subindex
+ObjectType=0x7
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x02
+PDOMapping=0x0
+
+[3050sub1]
+ParameterName=FactorAndDescription
+ObjectType=0x7
+DataType=0x0004
+AccessType=ro
+PDOMapping=0x0
+Factor=0.1
+Description=This is the a test description
+
+[3050sub2]
+ParameterName=Error Factor and No Description
+ObjectType=0x7
+DataType=0x0004
+AccessType=ro
+PDOMapping=0x0
+Factor=ERROR
+Description=

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -111,6 +111,16 @@ class TestEDS(unittest.TestCase):
     def test_dummy_variable_undefined(self):
         with self.assertRaises(KeyError):
             var_undef = self.od['Dummy0001']
+    
+    def test_reading_factor(self):
+        var = self.od['EDS file extensions']['FactorAndDescription']
+        self.assertEqual(var.factor, 0.1)
+        self.assertEqual(var.description, "This is the a test description")
+        var2 = self.od['EDS file extensions']['Error Factor and No Description']
+        self.assertEqual(var2.description, '')
+        self.assertEqual(var2.factor, 1)
+        
+
 
     def test_comments(self):
         self.assertEqual(self.od.comments,

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -116,9 +116,11 @@ class TestEDS(unittest.TestCase):
         var = self.od['EDS file extensions']['FactorAndDescription']
         self.assertEqual(var.factor, 0.1)
         self.assertEqual(var.description, "This is the a test description")
+        self.assertEqual(var.unit,'mV')
         var2 = self.od['EDS file extensions']['Error Factor and No Description']
         self.assertEqual(var2.description, '')
         self.assertEqual(var2.factor, 1)
+        self.assertEqual(var2.unit, '')
         
 
 


### PR DESCRIPTION
For my work, i needed to use the Factor and Description, that already seem to have been implemented CANopen. However, they were currently not/never set by an EDS-file.
I added parsing for the Factor and Description, and i have added some unit-tests for them.