### PR TITLE
Enable inline comments when reading files

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -21,7 +21,7 @@ RECORD = 9
 
 
 def import_eds(source, node_id):
-    eds = RawConfigParser()
+    eds = RawConfigParser(inline_comment_prefixes=(';',))
     eds.optionxform = str
     if hasattr(source, "read"):
         fp = source


### PR DESCRIPTION
Some dcf/eds files contain inline comments, seperated by ';'. This fix allows those files to be read.

For example: 
DataType=0x0007  ; Unsigned32