### PR TITLE
Support of custom can.Bus implementations to the Network class

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -33,7 +33,7 @@ Callback = Callable[[int, bytearray, float], None]
 class Network(MutableMapping):
     """Representation of one CAN bus containing one or more nodes."""
 
-    def __init__(self, bus=None):
+    def __init__(self, bus: can.BusABC | None = None):
         """
         :param can.BusABC bus:
             A python-can bus instance to re-use.
@@ -110,7 +110,8 @@ class Network(MutableMapping):
                 if node.object_dictionary.bitrate:
                     kwargs["bitrate"] = node.object_dictionary.bitrate
                     break
-        self.bus = can.interface.Bus(*args, **kwargs)
+        if self.bus is None:
+            self.bus = can.Bus(*args, **kwargs)
         logger.info("Connected to '%s'", self.bus.channel_info)
         self.notifier = can.Notifier(self.bus, self.listeners, 1)
         return self


### PR DESCRIPTION
The fixed bug relates to the inability to use a custom can.BusABC implementation in the Network connection process due to hard-coded instantiation of the can.Bus object in the `connect` method.