### PR TITLE
Add `from_od` flag to the `RemoteNode.load_configuration`

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -33,7 +33,7 @@ Callback = Callable[[int, bytearray, float], None]
 class Network(MutableMapping):
     """Representation of one CAN bus containing one or more nodes."""
 
-    def __init__(self, bus=None):
+    def __init__(self, bus: can.BusABC | None = None):
         """
         :param can.BusABC bus:
             A python-can bus instance to re-use.
@@ -110,7 +110,8 @@ class Network(MutableMapping):
                 if node.object_dictionary.bitrate:
                     kwargs["bitrate"] = node.object_dictionary.bitrate
                     break
-        self.bus = can.interface.Bus(*args, **kwargs)
+        if self.bus is None:
+            self.bus = can.Bus(*args, **kwargs)
         logger.info("Connected to '%s'", self.bus.channel_info)
         self.notifier = can.Notifier(self.bus, self.listeners, 1)
         return self

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -145,7 +145,7 @@ class RemoteNode(BaseNode):
                 logger.warning('[ERROR SETTING object {0:#06x}:{1:#06x}]  {2}'.format(index, subindex, str(e)))
                 raise
 
-    def load_configuration(self):
+    def load_configuration(self, from_od: bool = False):
         ''' Load the configuration of the node from the object dictionary.'''
         for obj in self.object_dictionary.values():
             if isinstance(obj, ODRecord) or isinstance(obj, ODArray):
@@ -154,4 +154,4 @@ class RemoteNode(BaseNode):
                         self.__load_configuration_helper(subobj.index, subobj.subindex, subobj.name, subobj.value)
             elif isinstance(obj, ODVariable) and obj.writable and (obj.value is not None):
                 self.__load_configuration_helper(obj.index, None, obj.name, obj.value)
-        self.pdo.read()  # reads the new configuration from the driver
+        self.pdo.read(from_od=from_od)  # reads the new configuration from the driver


### PR DESCRIPTION
In the library we have some methods to load settings from OD, for example `node.rpdo.read(from_od=True)`, but we can not do this for entire configuration.
This PR fixes it.