### PR TITLE
objectdictionary: Fix incorrect ParameterValue when export_dcf

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -383,7 +383,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
                 eds.set(section, "ParameterValue", var.value_raw)
             elif getattr(var, 'value', None) is not None:
                 eds.set(section, "ParameterValue",
-                        _revert_variable(var.data_type, var.default))
+                        _revert_variable(var.data_type, var.value))
 
         eds.set(section, "DataType", "0x%04X" % var.data_type)
         eds.set(section, "PDOMapping", hex(var.pdo_mappable))


### PR DESCRIPTION
I used `objectdictionary.export_dcf()` to export configured values into DCF file for commissioning devices and noticed that the exported DCF file has ParameterValue set to its DefaultValue instead of the commissioned value, which resulted in incorrect device behavior after applying the DCF to the node.

Submitting a PR to fix this.  Thanks!