### PR TITLE
Ignore the most significant bit in PDO mapping lengths

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -358,11 +358,12 @@ class Map:
             value = _raw_from(self.map_array[subindex])
             index = value >> 16
             subindex = (value >> 8) & 0xFF
-            size = value & 0xFF
+            # Ignore the highest bit, it is never valid for <= 64 PDO length
+            size = value & 0x7F
             if hasattr(self.pdo_node.node, "curtis_hack") and self.pdo_node.node.curtis_hack:  # Curtis HACK: mixed up field order
                 index = value & 0xFFFF
                 subindex = (value >> 16) & 0xFF
-                size = (value >> 24) & 0xFF
+                size = (value >> 24) & 0x7F
             if index and size:
                 self.add_variable(index, subindex, size)
 


### PR DESCRIPTION
The maximum size of a PDO is 64 bits = 0x40.  Any higher value is per definition invalid, so the highest bit is definitely unused.

This prompted at least one device manufacturer (miControl GmbH) to utilize this bit for their own purpose.  They state in their manual that the device supports only the following lengths: 8 (0x08), 16 (0x10), 32 (0x20) bits.  However, the device allows setting the highest bit as well, to indicate the mapping concerns a signed variable.  This triggers the appropriate sign bit padding when receiving the value, as all internal variable accesses are handled as INTEGER32.

When such a PDO mapping is read in, the total PDO size calculation in the canopen library fails badly.  Thus the easy fix is to just always mask out that highest bit, which is never a meaningful part of the length field.