### PR TITLE
Implement abstract method can.Listener.stop() in MessageListener

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -363,6 +363,9 @@ class MessageListener(Listener):
             # Exceptions in any callbaks should not affect CAN processing
             logger.error(str(e))
 
+    def stop(self) -> None:
+        """Override abstract base method to release any resources."""
+
 
 class NodeScanner:
     """Observes which nodes are present on the bus.


### PR DESCRIPTION
Avoid errors with the upcoming changes in python-can, as discussed in https://github.com/hardbyte/python-can/issues/1770.

This is a prerequisite for compatibility with the upcoming release of python-can (tentatively v4.4.0).