### PR TITLE
Add support for using dot (.) to get subobjects from the OD

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -109,8 +109,8 @@ class ObjectDictionary(MutableMapping):
         item = self.names.get(index) or self.indices.get(index)
         if item is None:
             if isinstance(index, str) and '.' in index:
-                parts = index.split('.')
-                return self[parts[0]][".".join(parts[1:])]
+                idx, sub = index.split('.', maxsplit=1)
+                return self[idx][sub]
             name = "0x%X" % index if isinstance(index, int) else index
             raise KeyError("%s was not found in Object Dictionary" % name)
         return item

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -108,6 +108,9 @@ class ObjectDictionary(MutableMapping):
         """Get object from object dictionary by name or index."""
         item = self.names.get(index) or self.indices.get(index)
         if item is None:
+            if isinstance(index, str) and '.' in index:
+                parts = index.split('.')
+                return self[parts[0]][".".join(parts[1:])]
             name = "0x%X" % index if isinstance(index, int) else index
             raise KeyError("%s was not found in Object Dictionary" % name)
         return item

--- a/doc/od.rst
+++ b/doc/od.rst
@@ -48,7 +48,8 @@ You can access the objects using either index/subindex or names::
 
     device_name_obj = node.object_dictionary['ManufacturerDeviceName']
     vendor_id_obj = node.object_dictionary[0x1018][1]
-
+    actual_speed = node.object_dictionary['ApplicationStatus.ActualSpeed']
+    command_all = node.object_dictionary['ApplicationCommands.CommandAll']
 
 API
 ---

--- a/doc/sdo.rst
+++ b/doc/sdo.rst
@@ -30,11 +30,14 @@ Examples
 --------
 
 SDO objects can be accessed using the ``.sdo`` member which works like a Python
-dictionary. Indexes and subindexes can be identified by either name or number.
+dictionary. Indexes can be identified by either name or number.
+There are two ways to idenity subindexes, either by using the index and subindex
+as separate arguments or by using a combined syntax using a dot.
 The code below only creates objects, no messages are sent or received yet::
 
     # Complex records
     command_all = node.sdo['ApplicationCommands']['CommandAll']
+    command_all = node.sdo['ApplicationCommands.CommandAll']
     actual_speed = node.sdo['ApplicationStatus']['ActualSpeed']
     control_mode = node.sdo['ApplicationSetupParameters']['RequestedControlMode']
 

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -136,6 +136,20 @@ class TestObjectDictionary(unittest.TestCase):
         self.assertEqual(test_od["Test Array"], array)
         self.assertEqual(test_od[0x1002], array)
 
+    def test_get_item_dot(self):
+        test_od = od.ObjectDictionary()
+        array = od.ODArray("Test Array", 0x1000)
+        last_subindex = od.ODVariable("Last subindex", 0x1000, 0)
+        last_subindex.data_type = od.UNSIGNED8
+        member1 = od.ODVariable("Test Variable", 0x1000, 1)
+        member2 = od.ODVariable("Test Variable 2", 0x1000, 2)
+        array.add_member(last_subindex)
+        array.add_member(member1)
+        array.add_member(member2)
+        test_od.add_object(array)
+        self.assertEqual(test_od["Test Array.Last subindex"], last_subindex)
+        self.assertEqual(test_od["Test Array.Test Variable"], member1)
+        self.assertEqual(test_od["Test Array.Test Variable 2"], member2)
 
 class TestArray(unittest.TestCase):
 


### PR DESCRIPTION
This PR introduces the ability to use dot to access sub objects from the OD.

```python
od: ObjectDictionary
v = od["Parameter"]["Subparam"].raw   # The current way
v = od["Parameter.Subparam"].raw      # The newly added way
```

The rationale is that when working with PDOs this syntax is used and it would make sense to have the same mechanism for SDO.

```python
rpdo = remotenote.rpdo[1]
rpdo["Parameter.Subparam"].phys = 80

sdo = remotenode.sdo
sdo["Parameter.SubParam"].phys = 80
```

The current ways of accessing using multiple `__getitem__` works fine. The only drawback is if an object has period (.) in its name.

Unittests have been updated as a part of this PR.