### PR TITLE
Add configurable pause after sending SDO request

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -28,6 +28,9 @@ class SdoClient(SdoBase):
     #: Seconds to wait before sending a request, for rate limiting
     PAUSE_BEFORE_SEND = 0.0
 
+    #: Seconds to wait after sending a request
+    PAUSE_AFTER_SEND = 0.0
+
     def __init__(self, rx_cobid, tx_cobid, od):
         """
         :param int rx_cobid:
@@ -56,7 +59,8 @@ class SdoClient(SdoBase):
                 if not retries_left:
                     raise
                 logger.info(str(e))
-                time.sleep(0.1)
+                if self.PAUSE_AFTER_SEND:
+                    time.sleep(self.PAUSE_AFTER_SEND)
             else:
                 break
 


### PR DESCRIPTION
This is a minor fix that introduces a configurable class variable to set the delay after sending an SDO request. This is instead of having a hardcoded value.

The same should probably be done for `lss.py`, but I don't really have an LSS-compatible CANopen-device, so I cannot verify it.