### PR TITLE
Making SdoArray iterator behave equal to ODArray and *Record

### DIFF
--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -122,7 +122,7 @@ class SdoArray(Mapping):
         return SdoVariable(self.sdo_node, self.od[subindex])
 
     def __iter__(self) -> Iterable[int]:
-        return iter(range(1, len(self) + 1))
+        return iter(self.od)
 
     def __len__(self) -> int:
         return self[0].raw


### PR DESCRIPTION
Iterating over an `SdoArray` and iterating over an `ODArray` object reveals different results.

```py
# Load an OD that contains "MyArray" at 0x2000 with sub elements
#    0: Number of elements = 2
#    1: Element 1
#    2: Element 2
node: RemoteNode

# From object_dictionary (iterate over ODArray)
a = [i for i in node.object_dictionary["MyArray"]]   # Results in [0, 1, 2]

# From SDO (iterate over SdoArray)
b = [i for i in node.sdo["MyArray"]]  # Results in [1, 2]
```

The `SdoRecord` behaves expectantly:

```py
a = [i for i in node.object_dictionary["MyRecord"]]   # Results in [0, 1, 2]
b = [i for i in node.sdo["MyRecord"]]  # Results in [0, 1, 2]
```

This PR adds that the iterator for `SdoArray` include index 0. This is consistent with the iterator of `ODArray`, `ODRecord` and `SdoRecord`.
