### PR TITLE
Rename Maps to PdoMaps and Map to PdoMap

### DIFF
--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from canopen import node
-from canopen.pdo.base import PdoBase, Maps
+from canopen.pdo.base import PdoBase, PdoMaps
 
 # Compatibility
 from .base import Variable
@@ -38,7 +38,7 @@ class RPDO(PdoBase):
 
     def __init__(self, node):
         super(RPDO, self).__init__(node)
-        self.map = Maps(0x1400, 0x1600, self, 0x200)
+        self.map = PdoMaps(0x1400, 0x1600, self, 0x200)
         logger.debug('RPDO Map as {0}'.format(len(self.map)))
 
     def stop(self):
@@ -63,7 +63,7 @@ class TPDO(PdoBase):
 
     def __init__(self, node):
         super(TPDO, self).__init__(node)
-        self.map = Maps(0x1800, 0x1A00, self, 0x180)
+        self.map = PdoMaps(0x1800, 0x1A00, self, 0x180)
         logger.debug('TPDO Map as {0}'.format(len(self.map)))
 
     def stop(self):

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -124,7 +124,7 @@ class PdoBase(Mapping):
             pdo_map.stop()
 
 
-class PdoMaps(Mapping[int, "PdoMap"]):
+class PdoMaps(Mapping):
     """A collection of transmit or receive maps."""
 
     def __init__(self, com_offset, map_offset, pdo_node: PdoBase, cob_base=None):

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -27,7 +27,7 @@ class PdoBase(Mapping):
 
     def __init__(self, node):
         self.network = None
-        self.map = None  # instance of Maps
+        self.map = None  # instance of PdoMaps
         self.node = node
 
     def __iter__(self):
@@ -124,7 +124,7 @@ class PdoBase(Mapping):
             pdo_map.stop()
 
 
-class Maps(Mapping):
+class PdoMaps(Mapping[int, "PdoMap"]):
     """A collection of transmit or receive maps."""
 
     def __init__(self, com_offset, map_offset, pdo_node: PdoBase, cob_base=None):
@@ -134,10 +134,10 @@ class Maps(Mapping):
         :param pdo_node:
         :param cob_base:
         """
-        self.maps: Dict[int, "Map"] = {}
+        self.maps: Dict[int, "PdoMap"] = {}
         for map_no in range(512):
             if com_offset + map_no in pdo_node.node.object_dictionary:
-                new_map = Map(
+                new_map = PdoMap(
                     pdo_node,
                     pdo_node.node.sdo[com_offset + map_no],
                     pdo_node.node.sdo[map_offset + map_no])
@@ -146,7 +146,7 @@ class Maps(Mapping):
                     new_map.predefined_cob_id = cob_base + map_no * 0x100 + pdo_node.node.id
                 self.maps[map_no + 1] = new_map
 
-    def __getitem__(self, key: int) -> "Map":
+    def __getitem__(self, key: int) -> "PdoMap":
         return self.maps[key]
 
     def __iter__(self) -> Iterable[int]:
@@ -156,7 +156,7 @@ class Maps(Mapping):
         return len(self.maps)
 
 
-class Map:
+class PdoMap:
     """One message which can have up to 8 bytes of variables mapped."""
 
     def __init__(self, pdo_node, com_record, map_array):
@@ -304,12 +304,12 @@ class Map:
                 for callback in self.callbacks:
                     callback(self)
 
-    def add_callback(self, callback: Callable[["Map"], None]) -> None:
+    def add_callback(self, callback: Callable[["PdoMap"], None]) -> None:
         """Add a callback which will be called on receive.
 
         :param callback:
             The function to call which must take one argument of a
-            :class:`~canopen.pdo.Map`.
+            :class:`~canopen.pdo.PdoMap`.
         """
         self.callbacks.append(callback)
 
@@ -609,3 +609,5 @@ class PdoVariable(variable.Variable):
 
 # For compatibility
 Variable = PdoVariable
+Maps = PdoMaps
+Map = PdoMap

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -212,8 +212,8 @@ class BaseNode402(RemoteNode):
     def __init__(self, node_id, object_dictionary):
         super(BaseNode402, self).__init__(node_id, object_dictionary)
         self.tpdo_values = {}  # { index: value from last received TPDO }
-        self.tpdo_pointers = {}  # { index: pdo.Map instance }
-        self.rpdo_pointers = {}  # { index: pdo.Map instance }
+        self.tpdo_pointers = {}  # { index: pdo.PdoMap instance }
+        self.rpdo_pointers = {}  # { index: pdo.PdoMap instance }
 
     def setup_402_state_machine(self, read_pdos=True):
         """Configure the state machine by searching for a TPDO that has the StatusWord mapped.
@@ -459,7 +459,7 @@ class BaseNode402(RemoteNode):
         """Cache updated values from a TPDO received from this node.
 
         :param mapobject: The received PDO message.
-        :type mapobject: canopen.pdo.Map
+        :type mapobject: canopen.pdo.PdoMap
         """
         for obj in mapobject:
             self.tpdo_values[obj.index] = obj.raw

--- a/doc/pdo.rst
+++ b/doc/pdo.rst
@@ -89,7 +89,7 @@ API
 
    .. describe:: pdo[no]
 
-      Return the :class:`canopen.pdo.Map` for the specified map number.
+      Return the :class:`canopen.pdo.PdoMap` for the specified map number.
       First map starts at 1.
 
    .. describe:: iter(pdo)
@@ -101,7 +101,7 @@ API
       Return the number of supported maps.
 
 
-.. autoclass:: canopen.pdo.Map
+.. autoclass:: canopen.pdo.PdoMap
    :members:
 
    .. describe:: map[name]


### PR DESCRIPTION
This PR renames the class `canopen.pdo.base.Map` to `canopen.pdo.base.PdoMap` and correspondingly `.Map` to `PdoMap` in line with the similar change as PR #368. The names `PdoMap()` and `PdoMaps()` with respect to upper case "PDO" is chosen to be consistent with how `Sdo*` have been named.

Compatibility entries have been added, so this won't break old code.
