### PR TITLE
Clean up imports of old modules

### DIFF
--- a/canopen/lss.py
+++ b/canopen/lss.py
@@ -1,10 +1,7 @@
 import logging
 import time
 import struct
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import queue
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
+from collections.abc import MutableMapping
 import logging
 import threading
 from typing import Callable, Dict, Iterable, List, Optional, Union

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -3,10 +3,7 @@ Object Dictionary module
 """
 import struct
 from typing import Dict, Iterable, List, Optional, TextIO, Union
-try:
-    from collections.abc import MutableMapping, Mapping
-except ImportError:
-    from collections import MutableMapping, Mapping
+from collections.abc import MutableMapping, Mapping
 import logging
 
 from canopen.objectdictionary.datatypes import *

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -1,11 +1,7 @@
 import copy
 import logging
 import re
-
-try:
-    from configparser import RawConfigParser, NoOptionError, NoSectionError
-except ImportError:
-    from ConfigParser import RawConfigParser, NoOptionError, NoSectionError
+from configparser import RawConfigParser, NoOptionError, NoSectionError
 
 from canopen import objectdictionary
 from canopen.objectdictionary import ObjectDictionary, datatypes

--- a/canopen/objectdictionary/epf.py
+++ b/canopen/objectdictionary/epf.py
@@ -1,7 +1,4 @@
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import xml.etree.ElementTree as etree
+import xml.etree.ElementTree as etree
 import logging
 
 from canopen import objectdictionary

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -4,7 +4,7 @@ from canopen import node
 from canopen.pdo.base import PdoBase, Maps
 
 # Compatibility
-from .base import Variable
+from canopen.pdo.base import Variable
 
 logger = logging.getLogger(__name__)
 

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -1,10 +1,7 @@
 import threading
 import math
 from typing import Callable, Dict, Iterable, List, Optional, Union
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 import logging
 import binascii
 

--- a/canopen/sdo/__init__.py
+++ b/canopen/sdo/__init__.py
@@ -4,4 +4,4 @@ from canopen.sdo.server import SdoServer
 from canopen.sdo.exceptions import SdoAbortedError, SdoCommunicationError
 
 # Compatibility
-from .base import Variable, Record, Array
+from canopen.sdo.base import Variable, Record, Array

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -1,9 +1,6 @@
 import binascii
 from typing import Iterable, Optional, Union
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 from canopen import objectdictionary
 from canopen.objectdictionary import ObjectDictionary

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -2,10 +2,7 @@ import struct
 import logging
 import io
 import time
-try:
-    import queue
-except ImportError:
-    import Queue as queue
+import queue
 
 from canopen.network import CanError
 from canopen import objectdictionary

--- a/canopen/variable.py
+++ b/canopen/variable.py
@@ -1,9 +1,6 @@
 import logging
 from typing import Union
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 
 from canopen import objectdictionary
 


### PR DESCRIPTION
The canopen package have import leftovers from earlier versions of Python. This PR cleans up the no longer valid imports.

* `import Queue` dates to py 2
* `import collections.*Mapping` was changed to `collections.abc.*Mapping` in py 3.3
* `import ConfigParser` dates to py 2
* `import xml.etree.cElementTree` is deprecated since py 3.3. It will pick the fastest option when using `xml.etree.ElementTree`
* Fixed `.base` into `canopen.pdo.base` in canopen/pdo/__init__.py
* Fixed `.base` into `canopen.sdo.base` in canopen/sdo/__init__.py