### PR TITLE
Cleanup logging to use legacy format

### DIFF
--- a/canopen/lss.py
+++ b/canopen/lss.py
@@ -369,8 +369,7 @@ class LssMaster:
         """
 
         message_str = " ".join(["{:02x}".format(x) for x in message])
-        logger.info(
-            "Sending LSS message {}".format(message_str))
+        logger.info("Sending LSS message %s", message_str)
 
         response = None
         if not self.responses.empty():

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -138,7 +138,7 @@ class RemoteNode(BaseNode):
                 # Abort codes other than "Attempt to write a read-only object"
                 # should still be reported.
                 logger.warning('[ERROR SETTING object %#06x:%#06x]  %s',
-                               index, subindex, str(e))
+                               index, subindex, e)
                 raise
 
     def load_configuration(self):

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -122,18 +122,13 @@ class RemoteNode(BaseNode):
         """
         try:
             if subindex is not None:
-                logger.info(str('SDO [{index:#06x}][{subindex:#06x}]: {name}: {value:#06x}'.format(
-                    index=index,
-                    subindex=subindex,
-                    name=name,
-                    value=value)))
+                logger.info('SDO [%#06x][%#06x]: %s: %#06x',
+                            index, subindex, name, value)
                 self.sdo[index][subindex].raw = value
             else:
                 self.sdo[index].raw = value
-                logger.info(str('SDO [{index:#06x}]: {name}: {value:#06x}'.format(
-                    index=index,
-                    name=name,
-                    value=value)))
+                logger.info('SDO [%#06x]: %s: %#06x',
+                            index, name, value)
         except SdoCommunicationError as e:
             logger.warning(str(e))
         except SdoAbortedError as e:
@@ -142,7 +137,8 @@ class RemoteNode(BaseNode):
             if e.code != 0x06010002:
                 # Abort codes other than "Attempt to write a read-only object"
                 # should still be reported.
-                logger.warning('[ERROR SETTING object {0:#06x}:{1:#06x}]  {2}'.format(index, subindex, str(e)))
+                logger.warning('[ERROR SETTING object %#06x:%#06x]  %s',
+                               index, subindex, str(e))
                 raise
 
     def load_configuration(self):

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -417,8 +417,7 @@ class ODVariable:
                 if self.max is not None and value > self.max:
                     logger.warning(
                         "Value %d is greater than max value %d",
-                        value,
-                        self.max)
+                        value, self.max)
             try:
                 return self.STRUCT_TYPES[self.data_type].pack(value)
             except struct.error:

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -39,7 +39,7 @@ class RPDO(PdoBase):
     def __init__(self, node):
         super(RPDO, self).__init__(node)
         self.map = PdoMaps(0x1400, 0x1600, self, 0x200)
-        logger.debug('RPDO Map as {0}'.format(len(self.map)))
+        logger.debug('RPDO Map as %d', len(self.map))
 
     def stop(self):
         """Stop transmission of all RPDOs.
@@ -64,7 +64,7 @@ class TPDO(PdoBase):
     def __init__(self, node):
         super(TPDO, self).__init__(node)
         self.map = PdoMaps(0x1800, 0x1A00, self, 0x180)
-        logger.debug('TPDO Map as {0}'.format(len(self.map)))
+        logger.debug('TPDO Map as %d', len(self.map))
 
     def stop(self):
         """Stop transmission of all TPDOs.

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -249,7 +249,7 @@ class BaseNode402(RemoteNode):
             if tpdo.enabled:
                 tpdo.add_callback(self.on_TPDOs_update_callback)
                 for obj in tpdo:
-                    logger.debug('Configured TPDO: {0}'.format(obj.index))
+                    logger.debug('Configured TPDO: %s', obj.index)
                     if obj.index not in self.tpdo_values:
                         self.tpdo_values[obj.index] = 0
                         self.tpdo_pointers[obj.index] = obj
@@ -260,31 +260,31 @@ class BaseNode402(RemoteNode):
         for rpdo in self.rpdo.values():
             if rpdo.enabled:
                 for obj in rpdo:
-                    logger.debug('Configured RPDO: {0}'.format(obj.index))
+                    logger.debug('Configured RPDO: %s', obj.index)
                     if obj.index not in self.rpdo_pointers:
                         self.rpdo_pointers[obj.index] = obj
 
     def _check_controlword_configured(self):
         if 0x6040 not in self.rpdo_pointers:  # Controlword
             logger.warning(
-                "Controlword not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
-                    self.id))
+                "Controlword not configured in node %s's PDOs. Using SDOs can cause slow performance.",
+                self.id)
 
     def _check_statusword_configured(self):
         if 0x6041 not in self.tpdo_values:  # Statusword
             logger.warning(
-                "Statusword not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
-                    self.id))
+                "Statusword not configured in node %s's PDOs. Using SDOs can cause slow performance.",
+                self.id)
 
     def _check_op_mode_configured(self):
         if 0x6060 not in self.rpdo_pointers:  # Operation Mode
             logger.warning(
-                "Operation Mode not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
-                    self.id))
+                "Operation Mode not configured in node %s's PDOs. Using SDOs can cause slow performance.",
+                self.id)
         if 0x6061 not in self.tpdo_values:  # Operation Mode Display
             logger.warning(
-                "Operation Mode Display not configured in node {0}'s PDOs. Using SDOs can cause slow performance.".format(
-                    self.id))
+                "Operation Mode Display not configured in node %s's PDOs. Using SDOs can cause slow performance.",
+                self.id)
 
     def reset_from_fault(self):
         """Reset node from fault and set it to Operation Enable state."""
@@ -425,11 +425,11 @@ class BaseNode402(RemoteNode):
                     raise RuntimeError(
                         "Timeout setting node {0}'s new mode of operation to {1}.".format(
                             self.id, mode))
-            logger.info('Set node {n} operation mode to {m}.'.format(n=self.id, m=mode))
+            logger.info('Set node %s operation mode to %s.', self.id, mode)
         except SdoCommunicationError as e:
-            logger.warning('[SDO communication error] Cause: {0}'.format(str(e)))
+            logger.warning('[SDO communication error] Cause: %s', e)
         except (RuntimeError, ValueError) as e:
-            logger.warning('{0}'.format(str(e)))
+            logger.warning(str(e))
 
     def _clear_target_values(self):
         # [target velocity, target position, target torque]
@@ -450,8 +450,8 @@ class BaseNode402(RemoteNode):
         if not hasattr(self, '_op_mode_support'):
             # Cache value only on first lookup, this object should never change.
             self._op_mode_support = self.sdo[0x6502].raw
-            logger.info('Caching node {n} supported operation modes 0x{m:04X}'.format(
-                n=self.id, m=self._op_mode_support))
+            logger.info('Caching node %s supported operation modes 0x%04X',
+                        self.id, self._op_mode_support)
         bits = OperationMode.SUPPORTED[mode]
         return self._op_mode_support & bits == bits
 

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -429,7 +429,7 @@ class BaseNode402(RemoteNode):
         except SdoCommunicationError as e:
             logger.warning('[SDO communication error] Cause: %s', e)
         except (RuntimeError, ValueError) as e:
-            logger.warning(str(e))
+            logger.warning("%s", e)
 
     def _clear_target_values(self):
         # [target velocity, target position, target torque]

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -97,7 +97,7 @@ class SdoClient(SdoBase):
         # TODO: Is it necessary to include index and subindex?
         struct.pack_into("<L", request, 4, abort_code)
         self.send_request(request)
-        logger.error("Transfer aborted by client with code 0x{:08X}".format(abort_code))
+        logger.error("Transfer aborted by client with code 0x%08X", abort_code)
 
     def upload(self, index: int, subindex: int) -> bytes:
         """May be called to make a read operation without an Object Dictionary.
@@ -758,8 +758,8 @@ class BlockDownloadStream(io.RawIOBase):
         
     def _retransmit(self, ackseq, blksize):
         """Retransmit the failed block"""
-        logger.info(("%d of %d sequences were received. "
-                 "Will start retransmission") % (ackseq, self._blksize))
+        logger.info("%d of %d sequences were received. "
+                    "Will start retransmission", ackseq, self._blksize)
         # Sub blocks betwen ackseq and end of corrupted block need to be resent
         # Get the part of the block to resend
         block = self._current_block[ackseq:]

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -179,7 +179,7 @@ class SdoServer(SdoBase):
         data = struct.pack("<BHBL", RESPONSE_ABORTED,
                            self._index, self._subindex, abort_code)
         self.send_response(data)
-        # logger.error("Transfer aborted with code 0x{:08X}".format(abort_code))
+        # logger.error("Transfer aborted with code 0x%08X", abort_code)
 
     def upload(self, index: int, subindex: int) -> bytes:
         """May be called to make a read operation without an Object Dictionary.


### PR DESCRIPTION
This PR cleans up the use of the logger which recommends using the "%s" format and pass its arguments to logger instead of using `.format()` or f-strings.