### PR TITLE
Modernize type annotations and fix some discrepancies

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -1,7 +1,7 @@
 from collections.abc import MutableMapping
 import logging
 import threading
-from typing import Callable, Dict, Iterable, List, Optional, Union
+from typing import Callable, Dict, Iterator, List, Optional, Union
 
 try:
     import can
@@ -277,7 +277,7 @@ class Network(MutableMapping):
         self.nodes[node_id].remove_network()
         del self.nodes[node_id]
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(self.nodes)
 
     def __len__(self) -> int:

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import MutableMapping
 import logging
 import threading
@@ -82,7 +84,7 @@ class Network(MutableMapping):
         else:
             self.subscribers[can_id].remove(callback)
 
-    def connect(self, *args, **kwargs) -> "Network":
+    def connect(self, *args, **kwargs) -> Network:
         """Connect to CAN bus using python-can.
 
         Arguments are passed directly to :class:`can.BusABC`. Typically these
@@ -214,7 +216,7 @@ class Network(MutableMapping):
 
     def send_periodic(
         self, can_id: int, data: bytes, period: float, remote: bool = False
-    ) -> "PeriodicMessageTask":
+    ) -> PeriodicMessageTask:
         """Start sending a message periodically.
 
         :param can_id:

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -1,6 +1,8 @@
 """
 Object Dictionary module
 """
+from __future__ import annotations
+
 import struct
 from typing import Dict, Iterator, List, Optional, TextIO, Union
 from collections.abc import MutableMapping, Mapping
@@ -12,7 +14,7 @@ from canopen.objectdictionary.datatypes_24bit import Integer24, Unsigned24
 logger = logging.getLogger(__name__)
 
 
-def export_od(od, dest:Union[str,TextIO,None]=None, doc_type:Optional[str]=None):
+def export_od(od, dest: Union[str, TextIO, None] = None, doc_type: Optional[str] = None):
     """ Export :class: ObjectDictionary to a file.
 
     :param od:
@@ -54,7 +56,7 @@ def export_od(od, dest:Union[str,TextIO,None]=None, doc_type:Optional[str]=None)
 def import_od(
     source: Union[str, TextIO, None],
     node_id: Optional[int] = None,
-) -> "ObjectDictionary":
+) -> ObjectDictionary:
     """Parse an EDS, DCF, or EPF file.
 
     :param source:
@@ -101,7 +103,7 @@ class ObjectDictionary(MutableMapping):
 
     def __getitem__(
         self, index: Union[int, str]
-    ) -> Union["ODArray", "ODRecord", "ODVariable"]:
+    ) -> Union[ODArray, ODRecord, ODVariable]:
         """Get object from object dictionary by name or index."""
         item = self.names.get(index) or self.indices.get(index)
         if item is None:
@@ -113,7 +115,7 @@ class ObjectDictionary(MutableMapping):
         return item
 
     def __setitem__(
-        self, index: Union[int, str], obj: Union["ODArray", "ODRecord", "ODVariable"]
+        self, index: Union[int, str], obj: Union[ODArray, ODRecord, ODVariable]
     ):
         assert index == obj.index or index == obj.name
         self.add_object(obj)
@@ -132,7 +134,7 @@ class ObjectDictionary(MutableMapping):
     def __contains__(self, index: Union[int, str]):
         return index in self.names or index in self.indices
 
-    def add_object(self, obj: Union["ODArray", "ODRecord", "ODVariable"]) -> None:
+    def add_object(self, obj: Union[ODArray, ODRecord, ODVariable]) -> None:
         """Add object to the object dictionary.
 
         :param obj:
@@ -147,7 +149,7 @@ class ObjectDictionary(MutableMapping):
 
     def get_variable(
         self, index: Union[int, str], subindex: int = 0
-    ) -> Optional["ODVariable"]:
+    ) -> Optional[ODVariable]:
         """Get the variable object at specified index (and subindex if applicable).
 
         :return: ODVariable if found, else `None`
@@ -182,13 +184,13 @@ class ODRecord(MutableMapping):
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.name!r} at 0x{self.index:04X}>"
 
-    def __getitem__(self, subindex: Union[int, str]) -> "ODVariable":
+    def __getitem__(self, subindex: Union[int, str]) -> ODVariable:
         item = self.names.get(subindex) or self.subindices.get(subindex)
         if item is None:
             raise KeyError("Subindex %s was not found" % subindex)
         return item
 
-    def __setitem__(self, subindex: Union[int, str], var: "ODVariable"):
+    def __setitem__(self, subindex: Union[int, str], var: ODVariable):
         assert subindex == var.subindex
         self.add_member(var)
 
@@ -206,10 +208,10 @@ class ODRecord(MutableMapping):
     def __contains__(self, subindex: Union[int, str]) -> bool:
         return subindex in self.names or subindex in self.subindices
 
-    def __eq__(self, other: "ODRecord") -> bool:
+    def __eq__(self, other: ODRecord) -> bool:
         return self.index == other.index
 
-    def add_member(self, variable: "ODVariable") -> None:
+    def add_member(self, variable: ODVariable) -> None:
         """Adds a :class:`~canopen.objectdictionary.ODVariable` to the record."""
         variable.parent = self
         self.subindices[variable.subindex] = variable
@@ -241,7 +243,7 @@ class ODArray(Mapping):
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.name!r} at 0x{self.index:04X}>"
 
-    def __getitem__(self, subindex: Union[int, str]) -> "ODVariable":
+    def __getitem__(self, subindex: Union[int, str]) -> ODVariable:
         var = self.names.get(subindex) or self.subindices.get(subindex)
         if var is not None:
             # This subindex is defined
@@ -267,10 +269,10 @@ class ODArray(Mapping):
     def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.subindices))
 
-    def __eq__(self, other: "ODArray") -> bool:
+    def __eq__(self, other: ODArray) -> bool:
         return self.index == other.index
 
-    def add_member(self, variable: "ODVariable") -> None:
+    def add_member(self, variable: ODVariable) -> None:
         """Adds a :class:`~canopen.objectdictionary.ODVariable` to the record."""
         variable.parent = self
         self.subindices[variable.subindex] = variable
@@ -348,7 +350,7 @@ class ODVariable:
             return f"{self.parent.name}.{self.name}"
         return self.name
 
-    def __eq__(self, other: "ODVariable") -> bool:
+    def __eq__(self, other: ODVariable) -> bool:
         return (self.index == other.index and
                 self.subindex == other.subindex)
 

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -2,7 +2,7 @@
 Object Dictionary module
 """
 import struct
-from typing import Dict, Iterable, List, Optional, TextIO, Union
+from typing import Dict, Iterator, List, Optional, TextIO, Union
 from collections.abc import MutableMapping, Mapping
 import logging
 
@@ -123,7 +123,7 @@ class ObjectDictionary(MutableMapping):
         del self.indices[obj.index]
         del self.names[obj.name]
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.indices))
 
     def __len__(self) -> int:
@@ -200,7 +200,7 @@ class ODRecord(MutableMapping):
     def __len__(self) -> int:
         return len(self.subindices)
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.subindices))
 
     def __contains__(self, subindex: Union[int, str]) -> bool:
@@ -264,7 +264,7 @@ class ODArray(Mapping):
     def __len__(self) -> int:
         return len(self.subindices)
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(sorted(self.subindices))
 
     def __eq__(self, other: "ODArray") -> bool:

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -1,6 +1,6 @@
 import threading
 import math
-from typing import Callable, Dict, Iterable, List, Optional, Union
+from typing import Callable, Dict, Iterator, List, Optional, Union
 from collections.abc import Mapping
 import logging
 import binascii
@@ -146,7 +146,7 @@ class PdoMaps(Mapping):
     def __getitem__(self, key: int) -> "PdoMap":
         return self.maps[key]
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(self.maps)
 
     def __len__(self) -> int:
@@ -229,7 +229,7 @@ class PdoMap:
                 var = self.__getitem_by_name(key)
         return var
 
-    def __iter__(self) -> Iterable["PdoVariable"]:
+    def __iter__(self) -> Iterator["PdoVariable"]:
         return iter(self.map)
 
     def __len__(self) -> int:

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -540,7 +540,7 @@ class PdoVariable(variable.Variable):
 
     def __init__(self, od: objectdictionary.ODVariable):
         #: PDO object that is associated with this ODVariable Object
-        self.pdo_parent = None
+        self.pdo_parent: Optional[PdoMap] = None
         #: Location of variable in the message in bits
         self.offset = None
         self.length = len(od)

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -215,7 +215,6 @@ class PdoMap:
             value, ', '.join(valid_values)))
 
     def __getitem__(self, key: Union[int, str]) -> "PdoVariable":
-        var = None
         if isinstance(key, int):
             # there is a maximum available of 8 slots per PDO map
             if key in range(0, 8):

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import binascii
-from typing import Iterable, Optional, Union
+from typing import Iterator, Optional, Union
 from collections.abc import Mapping
 
 from canopen import objectdictionary
-from canopen.objectdictionary import ObjectDictionary
 from canopen import variable
 
 
@@ -29,7 +30,7 @@ class SdoBase(Mapping):
         self,
         rx_cobid: int,
         tx_cobid: int,
-        od: ObjectDictionary,
+        od: objectdictionary.ObjectDictionary,
     ):
         """
         :param rx_cobid:
@@ -46,7 +47,7 @@ class SdoBase(Mapping):
 
     def __getitem__(
         self, index: Union[str, int]
-    ) -> Union["SdoVariable", "SdoArray", "SdoRecord"]:
+    ) -> Union[SdoVariable, SdoArray, SdoRecord]:
         entry = self.od[index]
         if isinstance(entry, objectdictionary.ODVariable):
             return SdoVariable(self, entry)
@@ -55,7 +56,7 @@ class SdoBase(Mapping):
         elif isinstance(entry, objectdictionary.ODRecord):
             return SdoRecord(self, entry)
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(self.od)
 
     def __len__(self) -> int:
@@ -66,7 +67,7 @@ class SdoBase(Mapping):
 
     def get_variable(
         self, index: Union[int, str], subindex: int = 0
-    ) -> Optional["SdoVariable"]:
+    ) -> Optional[SdoVariable]:
         """Get the variable object at specified index (and subindex if applicable).
 
         :return: SdoVariable if found, else `None`
@@ -92,17 +93,17 @@ class SdoBase(Mapping):
 
 class SdoRecord(Mapping):
 
-    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ODRecord):
         self.sdo_node = sdo_node
         self.od = od
 
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.od.name!r} at 0x{self.od.index:04X}>"
 
-    def __getitem__(self, subindex: Union[int, str]) -> "SdoVariable":
+    def __getitem__(self, subindex: Union[int, str]) -> SdoVariable:
         return SdoVariable(self.sdo_node, self.od[subindex])
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(self.od)
 
     def __len__(self) -> int:
@@ -114,17 +115,17 @@ class SdoRecord(Mapping):
 
 class SdoArray(Mapping):
 
-    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ODArray):
         self.sdo_node = sdo_node
         self.od = od
 
     def __repr__(self) -> str:
         return f"<{type(self).__qualname__} {self.od.name!r} at 0x{self.od.index:04X}>"
 
-    def __getitem__(self, subindex: Union[int, str]) -> "SdoVariable":
+    def __getitem__(self, subindex: Union[int, str]) -> SdoVariable:
         return SdoVariable(self.sdo_node, self.od[subindex])
 
-    def __iter__(self) -> Iterable[int]:
+    def __iter__(self) -> Iterator[int]:
         return iter(range(1, len(self) + 1))
 
     def __len__(self) -> int:
@@ -137,7 +138,7 @@ class SdoArray(Mapping):
 class SdoVariable(variable.Variable):
     """Access object dictionary variable values using SDO protocol."""
 
-    def __init__(self, sdo_node: SdoBase, od: ObjectDictionary):
+    def __init__(self, sdo_node: SdoBase, od: objectdictionary.ODVariable):
         self.sdo_node = sdo_node
         variable.Variable.__init__(self, od)
 


### PR DESCRIPTION
* Clarify that each SDO object has its corresponding OD entry linked in the `.od` attribute, not the whole `ObjectDictionary`.

* `__iter__()` should return `Iterator` like in `Mapping`, not `Iterable`.

* Use postponed evaluation of type annotations (PEP-563 / PEP-649 style) instead of stringized type annotations.