### PR TITLE
Revert "change missing Baudrate to BaudRate"

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -85,7 +85,7 @@ def import_eds(source, node_id):
                 pass
 
     if eds.has_section("DeviceComissioning"):
-        od.bitrate = int(eds.get("DeviceComissioning", "BaudRate")) * 1000
+        od.bitrate = int(eds.get("DeviceComissioning", "Baudrate")) * 1000
         od.node_id = int(eds.get("DeviceComissioning", "NodeID"), 0)
 
     for section in eds.sections():
@@ -467,7 +467,7 @@ def export_eds(od, dest=None, file_info={}, device_commisioning=False):
     if device_commisioning and (od.bitrate or od.node_id):
         eds.add_section("DeviceComissioning")
         if od.bitrate:
-            eds.set("DeviceComissioning", "BaudRate", int(od.bitrate / 1000))
+            eds.set("DeviceComissioning", "Baudrate", int(od.bitrate / 1000))
         if od.node_id:
             eds.set("DeviceComissioning", "NodeID", int(od.node_id))
 


### PR DESCRIPTION
The CiA 306 CANopen electronic data sheet (EDS) standard is quite clear that in the DeviceCommisioning block, baudrate is spelled 'Baudrate' and not 'BaudRate'. This commit is to be reverted, as it prevents loading of standards compliant DCF files.

Chapter 5.3.3.3 is clear in the casing of Baudrate for DeviceCommisioning and BaudRate for DeviceInfo. This seems to be an inconcistency in the standard, and we should probably accept both as a long term solution.

This reverts commit 074cbbc4d4c2c7803dc1e0151f6f534dbe44efc8.

This fixes #347 its duplicate #450 