### PR TITLE
Fix "hearbeat" typos (fixes #389)

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -163,13 +163,16 @@ class NmtMaster(NmtBase):
             if self._state_received == 0:
                 break
 
-    def add_hearbeat_callback(self, callback: Callable[[int], None]):
+    def add_heartbeat_callback(self, callback: Callable[[int], None]):
         """Add function to be called on heartbeat reception.
 
         :param callback:
             Function that should accept an NMT state as only argument.
         """
         self._callbacks.append(callback)
+
+    # Compatibility with previous typo
+    add_hearbeat_callback = add_heartbeat_callback
 
     def start_node_guarding(self, period: float):
         """Starts the node guarding mechanism.
@@ -225,16 +228,16 @@ class NmtSlave(NmtBase):
 
     def on_write(self, index, data, **kwargs):
         if index == 0x1017:
-            hearbeat_time, = struct.unpack_from("<H", data)
-            if hearbeat_time == 0:
+            heartbeat_time, = struct.unpack_from("<H", data)
+            if heartbeat_time == 0:
                 self.stop_heartbeat()
             else:
-                self.start_heartbeat(hearbeat_time)
+                self.start_heartbeat(heartbeat_time)
 
     def start_heartbeat(self, heartbeat_time_ms: int):
-        """Start the hearbeat service.
+        """Start the heartbeat service.
 
-        :param hearbeat_time
+        :param heartbeat_time_ms
             The heartbeat time in ms. If the heartbeat time is 0
             the heartbeating will not start.
         """
@@ -242,12 +245,12 @@ class NmtSlave(NmtBase):
 
         self.stop_heartbeat()
         if heartbeat_time_ms > 0:
-            logger.info("Start the hearbeat timer, interval is %d ms", self._heartbeat_time_ms)
+            logger.info("Start the heartbeat timer, interval is %d ms", self._heartbeat_time_ms)
             self._send_task = self.network.send_periodic(
                 0x700 + self.id, [self._state], heartbeat_time_ms / 1000.0)
 
     def stop_heartbeat(self):
-        """Stop the hearbeat service."""
+        """Stop the heartbeat service."""
         if self._send_task is not None:
             logger.info("Stop the heartbeat timer")
             self._send_task.stop()

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -89,7 +89,7 @@ class TestSDO(unittest.TestCase):
         self.assertEqual(value, b"Another cool device")
 
     def test_slave_send_heartbeat(self):
-        # Setting the heartbeat time should trigger hearbeating
+        # Setting the heartbeat time should trigger heartbeating
         # to start
         self.remote_node.sdo["Producer heartbeat time"].raw = 1000
         state = self.remote_node.nmt.wait_for_heartbeat()


### PR DESCRIPTION
Rename the misspelled NmtMaster.add_hearbeat_callback() function to add_heartbeat_callback, with an assignment for the legacy name to not break compatibility in an unexpected manner.

Adjust parameter / function documentation and local variables with the same typo consistently.