### PR TITLE
Python Warnings and PEP8: unused vars, var naming, typing, spelling etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ target/
 
 # IDEs
 .vscode/
+.idea/
 
 *.dbc
 

--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -1,5 +1,5 @@
-import struct
 import logging
+import struct
 import threading
 import time
 from typing import Callable, List, Optional
@@ -8,90 +8,6 @@ from typing import Callable, List, Optional
 EMCY_STRUCT = struct.Struct("<HB5s")
 
 logger = logging.getLogger(__name__)
-
-
-class EmcyConsumer:
-
-    def __init__(self):
-        #: Log of all received EMCYs for this node
-        self.log: List["EmcyError"] = []
-        #: Only active EMCYs. Will be cleared on Error Reset
-        self.active: List["EmcyError"] = []
-        self.callbacks = []
-        self.emcy_received = threading.Condition()
-
-    def on_emcy(self, can_id, data, timestamp):
-        code, register, data = EMCY_STRUCT.unpack(data)
-        entry = EmcyError(code, register, data, timestamp)
-
-        with self.emcy_received:
-            if code & 0xFF00 == 0:
-                # Error reset
-                self.active = []
-            else:
-                self.active.append(entry)
-            self.log.append(entry)
-            self.emcy_received.notify_all()
-
-        for callback in self.callbacks:
-            callback(entry)
-
-    def add_callback(self, callback: Callable[["EmcyError"], None]):
-        """Get notified on EMCY messages from this node.
-
-        :param callback:
-            Callable which must take one argument of an
-            :class:`~canopen.emcy.EmcyError` instance.
-        """
-        self.callbacks.append(callback)
-
-    def reset(self):
-        """Reset log and active lists."""
-        self.log = []
-        self.active = []
-
-    def wait(
-        self, emcy_code: Optional[int] = None, timeout: float = 10
-    ) -> "EmcyError":
-        """Wait for a new EMCY to arrive.
-
-        :param emcy_code: EMCY code to wait for
-        :param timeout: Max time in seconds to wait
-
-        :return: The EMCY exception object or None if timeout
-        """
-        end_time = time.time() + timeout
-        while True:
-            with self.emcy_received:
-                prev_log_size = len(self.log)
-                self.emcy_received.wait(timeout)
-                if len(self.log) == prev_log_size:
-                    # Resumed due to timeout
-                    return None
-                # Get last logged EMCY
-                emcy = self.log[-1]
-                logger.info("Got %s", emcy)
-                if time.time() > end_time:
-                    # No valid EMCY received on time
-                    return None
-                if emcy_code is None or emcy.code == emcy_code:
-                    # This is the one we're interested in
-                    return emcy
-
-
-class EmcyProducer:
-
-    def __init__(self, cob_id: int):
-        self.network = None
-        self.cob_id = cob_id
-
-    def send(self, code: int, register: int = 0, data: bytes = b""):
-        payload = EMCY_STRUCT.pack(code, register, data)
-        self.network.send_message(self.cob_id, payload)
-
-    def reset(self, register: int = 0, data: bytes = b""):
-        payload = EMCY_STRUCT.pack(0, register, data)
-        self.network.send_message(self.cob_id, payload)
 
 
 class EmcyError(Exception):
@@ -135,3 +51,88 @@ class EmcyError(Exception):
         if description:
             text = text + ", " + description
         return text
+
+
+class EmcyConsumer:
+
+    def __init__(self):
+        #: Log of all received EMCYs for this node
+        self.log: List[EmcyError] = []
+        #: Only active EMCYs. Will be cleared on Error Reset
+        self.active: List[EmcyError] = []
+        self.callbacks = []
+        self.emcy_received = threading.Condition()
+
+    def on_emcy(self, can_id, data, timestamp):
+        _ = can_id
+        code, register, data = EMCY_STRUCT.unpack(data)
+        entry = EmcyError(code, register, data, timestamp)
+
+        with self.emcy_received:
+            if code & 0xFF00 == 0:
+                # Error reset
+                self.active = []
+            else:
+                self.active.append(entry)
+            self.log.append(entry)
+            self.emcy_received.notify_all()
+
+        for callback in self.callbacks:
+            callback(entry)
+
+    def add_callback(self, callback: Callable[[EmcyError], None]):
+        """Get notified on EMCY messages from this node.
+
+        :param callback:
+            Callable which must take one argument of an
+            :class:`~canopen.emcy.EmcyError` instance.
+        """
+        self.callbacks.append(callback)
+
+    def reset(self):
+        """Reset log and active lists."""
+        self.log = []
+        self.active = []
+
+    def wait(
+        self, emcy_code: Optional[int] = None, timeout: float = 10
+    ) -> Optional[EmcyError]:
+        """Wait for a new EMCY to arrive.
+
+        :param emcy_code: EMCY code to wait for
+        :param timeout: Max time in seconds to wait
+
+        :return: The EMCY exception object or None if timeout
+        """
+        end_time = time.time() + timeout
+        while True:
+            with self.emcy_received:
+                prev_log_size = len(self.log)
+                self.emcy_received.wait(timeout)
+                if len(self.log) == prev_log_size:
+                    # Resumed due to timeout
+                    return None
+                # Get last logged EMCY
+                emcy = self.log[-1]
+                logger.info("Got %s", emcy)
+                if time.time() > end_time:
+                    # No valid EMCY received on time
+                    return None
+                if emcy_code is None or emcy.code == emcy_code:
+                    # This is the one we're interested in
+                    return emcy
+
+
+class EmcyProducer:
+
+    def __init__(self, cob_id: int):
+        self.network = None
+        self.cob_id = cob_id
+
+    def send(self, code: int, register: int = 0, data: bytes = b""):
+        payload = EMCY_STRUCT.pack(code, register, data)
+        self.network.send_message(self.cob_id, payload)
+
+    def reset(self, register: int = 0, data: bytes = b""):
+        payload = EMCY_STRUCT.pack(0, register, data)
+        self.network.send_message(self.cob_id, payload)

--- a/canopen/lss.py
+++ b/canopen/lss.py
@@ -1,7 +1,7 @@
 import logging
-import time
-import struct
 import queue
+import struct
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -104,21 +104,20 @@ class LssMaster:
         """obsolete"""
         self.send_switch_state_global(mode)
 
-    def send_switch_state_selective(self,
-                                    vendorId, productCode, revisionNumber, serialNumber):
+    def send_switch_state_selective(self, vendor_id, product_code, revision_number, serial_number):
         """switch mode from WAITING_STATE to CONFIGURATION_STATE
         only if 128bits LSS address matches with the arguments.
         It sends 4 messages for each argument.
         Then wait the response from the slave.
         There will be no response if there is no matching slave
 
-        :param int vendorId:
+        :param int vendor_id:
             object index 0x1018 subindex 1
-        :param int productCode:
+        :param int product_code:
             object index 0x1018 subindex 2
-        :param int revisionNumber:
+        :param int revision_number:
             object index 0x1018 subindex 3
-        :param int serialNumber:
+        :param int serial_number:
             object index 0x1018 subindex 4
 
         :return:
@@ -127,10 +126,10 @@ class LssMaster:
         :rtype: bool
         """
 
-        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_VENDOR_ID, vendorId)
-        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_PRODUCT_CODE, productCode)
-        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_REVISION_NUMBER, revisionNumber)
-        response = self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_SERIAL_NUMBER, serialNumber)
+        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_VENDOR_ID, vendor_id)
+        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_PRODUCT_CODE, product_code)
+        self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_REVISION_NUMBER, revision_number)
+        response = self.__send_lss_address(CS_SWITCH_STATE_SELECTIVE_SERIAL_NUMBER, serial_number)
 
         cs = struct.unpack_from("<B", response)[0]
         if cs == CS_SWITCH_STATE_SELECTIVE_RESPONSE:
@@ -203,19 +202,21 @@ class LssMaster:
         self.__send_configure(CS_STORE_CONFIGURATION)
 
     def send_identify_remote_slave(self,
-                                   vendorId, productCode,
-                                   revisionNumberLow, revisionNumberHigh,
-                                   serialNumberLow, serialNumberHigh):
-
+                                   vendor_id,
+                                   product_code,
+                                   revision_number_low,
+                                   revision_number_high,
+                                   serial_number_low,
+                                   serial_number_high):
         """This command sends the range of LSS address to find the slave nodes
         in the specified range
 
-        :param int vendorId:
-        :param int productCode:
-        :param int revisionNumberLow:
-        :param int revisionNumberHigh:
-        :param int serialNumberLow:
-        :param int serialNumberHigh:
+        :param int vendor_id:
+        :param int product_code:
+        :param int revision_number_low:
+        :param int revision_number_high:
+        :param int serial_number_low:
+        :param int serial_number_high:
 
         :return:
             True if any slave responds.
@@ -225,12 +226,12 @@ class LssMaster:
 
         # TODO it should handle the multiple respones from slaves
 
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_VENDOR_ID, vendorId)
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_PRODUCT_CODE, productCode)
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_REVISION_NUMBER_LOW, revisionNumberLow)
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_REVISION_NUMBER_HIGH, revisionNumberHigh)
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_SERIAL_NUMBER_LOW, serialNumberLow)
-        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_SERIAL_NUMBER_HIGH, serialNumberHigh)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_VENDOR_ID, vendor_id)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_PRODUCT_CODE, product_code)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_REVISION_NUMBER_LOW, revision_number_low)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_REVISION_NUMBER_HIGH, revision_number_high)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_SERIAL_NUMBER_LOW, serial_number_low)
+        self.__send_lss_address(CS_IDENTIFY_REMOTE_SLAVE_SERIAL_NUMBER_HIGH, serial_number_high)
 
     def send_identify_non_configured_remote_slave(self):
         # TODO it should handle the multiple respones from slaves
@@ -261,7 +262,7 @@ class LssMaster:
                     lss_bit_check -= 1
 
                     if not self.__send_fast_scan_message(lss_id[lss_sub], lss_bit_check, lss_sub, lss_next):
-                        lss_id[lss_sub] |= 1<<lss_bit_check
+                        lss_id[lss_sub] |= 1 << lss_bit_check
 
                     time.sleep(0.01)
 
@@ -289,7 +290,7 @@ class LssMaster:
 
         cs = struct.unpack_from("<B", recv_msg)[0]
         if cs == CS_IDENTIFY_SLAVE:
-                return True
+            return True
 
         return False
 
@@ -391,6 +392,7 @@ class LssMaster:
         return response
 
     def on_message_received(self, can_id, data, timestamp):
+        _ = can_id, timestamp
         self.responses.put(bytes(data))
 
 

--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -1,6 +1,6 @@
-import threading
 import logging
 import struct
+import threading
 import time
 from typing import Callable, Optional
 
@@ -86,10 +86,7 @@ class NmtBase:
         - 'RESET'
         - 'RESET COMMUNICATION'
         """
-        if self._state in NMT_STATES:
-            return NMT_STATES[self._state]
-        else:
-            return self._state
+        return NMT_STATES.get(self._state, "")
 
     @state.setter
     def state(self, new_state: str):
@@ -180,7 +177,8 @@ class NmtMaster(NmtBase):
         :param period:
             Period (in seconds) at which the node guarding should be advertised to the slave node.
         """
-        if self._node_guarding_producer : self.stop_node_guarding()
+        if self._node_guarding_producer:
+            self.stop_node_guarding()
         self._node_guarding_producer = self.network.send_periodic(0x700 + self.id, None, period, True)
 
     def stop_node_guarding(self):
@@ -227,6 +225,7 @@ class NmtSlave(NmtBase):
             self.update_heartbeat()
 
     def on_write(self, index, data, **kwargs):
+        _ = kwargs
         if index == 0x1017:
             heartbeat_time, = struct.unpack_from("<H", data)
             if heartbeat_time == 0:

--- a/canopen/node/remote.py
+++ b/canopen/node/remote.py
@@ -142,12 +142,12 @@ class RemoteNode(BaseNode):
                 raise
 
     def load_configuration(self):
-        ''' Load the configuration of the node from the object dictionary.'''
+        """ Load the configuration of the node from the object dictionary."""
         for obj in self.object_dictionary.values():
             if isinstance(obj, ODRecord) or isinstance(obj, ODArray):
-                for subobj in obj.values():
-                    if isinstance(subobj, ODVariable) and subobj.writable and (subobj.value is not None):
-                        self.__load_configuration_helper(subobj.index, subobj.subindex, subobj.name, subobj.value)
+                for subject in obj.values():
+                    if isinstance(subject, ODVariable) and subject.writable and (subject.value is not None):
+                        self.__load_configuration_helper(subject.index, subject.subindex, subject.name, subject.value)
             elif isinstance(obj, ODVariable) and obj.writable and (obj.value is not None):
                 self.__load_configuration_helper(obj.index, None, obj.name, obj.value)
         self.pdo.read()  # reads the new configuration from the driver

--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -62,6 +62,8 @@ def import_od(
 
     :param source:
         Path to object dictionary file or a file like object or an EPF XML tree.
+    :param node_id:
+        Optional Node-ID to set, if not defined in the source
 
     :return:
         An Object Dictionary instance.
@@ -368,13 +370,13 @@ class ODVariable:
     def readable(self) -> bool:
         return "r" in self.access_type or self.access_type == "const"
 
-    def add_value_description(self, value: int, descr: str) -> None:
+    def add_value_description(self, value: int, desc: str) -> None:
         """Associate a value with a string description.
 
         :param value: Value to describe
         :param desc: Description of value
         """
-        self.value_descriptions[value] = descr
+        self.value_descriptions[value] = desc
 
     def add_bit_definition(self, name: str, bits: List[int]) -> None:
         """Associate bit(s) with a string description.
@@ -461,7 +463,7 @@ class ODVariable:
         raise ValueError(
             f"No value corresponds to '{desc}'. Valid values are: {valid_values}")
 
-    def decode_bits(self, value: int, bits: List[int]) -> int:
+    def decode_bits(self, value: int, bits: Union[str, List[int]]) -> int:
         try:
             bits = self.bit_definitions[bits]
         except (TypeError, KeyError):
@@ -471,7 +473,7 @@ class ODVariable:
             mask |= 1 << bit
         return (value & mask) >> min(bits)
 
-    def encode_bits(self, original_value: int, bits: List[int], bit_value: int):
+    def encode_bits(self, original_value: int, bits: Union[str, List[int]], bit_value: int):
         try:
             bits = self.bit_definitions[bits]
         except (TypeError, KeyError):
@@ -488,20 +490,20 @@ class ODVariable:
 class DeviceInformation:
     def __init__(self):
         self.allowed_baudrates = set()
-        self.vendor_name:Optional[str] = None
-        self.vendor_number:Optional[int] = None
-        self.product_name:Optional[str] = None
-        self.product_number:Optional[int] = None
-        self.revision_number:Optional[int] = None
-        self.order_code:Optional[str] = None
-        self.simple_boot_up_master:Optional[bool] = None
-        self.simple_boot_up_slave:Optional[bool] = None
-        self.granularity:Optional[int] = None
-        self.dynamic_channels_supported:Optional[bool] = None
-        self.group_messaging:Optional[bool] = None
-        self.nr_of_RXPDO:Optional[bool] = None
-        self.nr_of_TXPDO:Optional[bool] = None
-        self.LSS_supported:Optional[bool] = None
+        self.vendor_name: Optional[str] = None
+        self.vendor_number: Optional[int] = None
+        self.product_name: Optional[str] = None
+        self.product_number: Optional[int] = None
+        self.revision_number: Optional[int] = None
+        self.order_code: Optional[str] = None
+        self.simple_boot_up_master: Optional[bool] = None
+        self.simple_boot_up_slave: Optional[bool] = None
+        self.granularity: Optional[int] = None
+        self.dynamic_channels_supported: Optional[bool] = None
+        self.group_messaging: Optional[bool] = None
+        self.nr_of_RXPDO: Optional[bool] = None
+        self.nr_of_TXPDO: Optional[bool] = None
+        self.LSS_supported: Optional[bool] = None
 
 
 class ObjectDictionaryError(Exception):

--- a/canopen/objectdictionary/epf.py
+++ b/canopen/objectdictionary/epf.py
@@ -1,5 +1,5 @@
-import xml.etree.ElementTree as etree
 import logging
+from xml.etree import ElementTree
 
 from canopen import objectdictionary
 from canopen.objectdictionary import ObjectDictionary
@@ -32,10 +32,10 @@ def import_epf(epf):
     :rtype: canopen.ObjectDictionary
     """
     od = ObjectDictionary()
-    if etree.iselement(epf):
+    if ElementTree.iselement(epf):
         tree = epf
     else:
-        tree = etree.parse(epf).getroot()
+        tree = ElementTree.parse(epf).getroot()
 
     # Find and set default bitrate
     can_config = tree.find("Configuration/CANopen")

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,7 +1,12 @@
 import logging
+from typing import Union, TYPE_CHECKING
 
 from canopen import node
 from canopen.pdo.base import PdoBase, PdoMaps
+
+if TYPE_CHECKING:
+    from canopen import LocalNode, RemoteNode
+
 
 # Compatibility
 from canopen.pdo.base import Variable
@@ -16,8 +21,8 @@ class PDO(PdoBase):
     :param tpdo: TPDO object holding the Transmit PDO mappings
     """
 
-    def __init__(self, node, rpdo, tpdo):
-        super(PDO, self).__init__(node)
+    def __init__(self, pdo_node: Union['LocalNode', 'RemoteNode'], rpdo, tpdo):
+        super(PDO, self).__init__(pdo_node)
         self.rx = rpdo.map
         self.tx = tpdo.map
 
@@ -33,11 +38,11 @@ class RPDO(PdoBase):
     """Receive PDO to transfer data from somewhere to the represented node.
 
     Properties 0x1400 to 0x1403 | Mapping 0x1600 to 0x1603.
-    :param object node: Parent node for this object.
+    :param object rpdo_node: Parent node for this object.
     """
 
-    def __init__(self, node):
-        super(RPDO, self).__init__(node)
+    def __init__(self, rpdo_node: Union['LocalNode', 'RemoteNode']):
+        super(RPDO, self).__init__(rpdo_node)
         self.map = PdoMaps(0x1400, 0x1600, self, 0x200)
         logger.debug('RPDO Map as %d', len(self.map))
 
@@ -58,11 +63,11 @@ class TPDO(PdoBase):
     """Transmit PDO to broadcast data from the represented node to the network.
 
     Properties 0x1800 to 0x1803 | Mapping 0x1A00 to 0x1A03.
-    :param object node: Parent node for this object.
+    :param object tpdo_node: Parent node for this object.
     """
 
-    def __init__(self, node):
-        super(TPDO, self).__init__(node)
+    def __init__(self, tpdo_node: Union['LocalNode', 'RemoteNode']):
+        super(TPDO, self).__init__(tpdo_node)
         self.map = PdoMaps(0x1800, 0x1A00, self, 0x180)
         logger.debug('TPDO Map as %d', len(self.map))
 

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -75,6 +75,7 @@ class PdoBase(Mapping):
         for pdo_map in self.map.values():
             pdo_map.subscribe()
 
+    # noinspection PyUnresolvedReferences,PyPackageRequirements
     def export(self, filename):
         """Export current configuration to a database file.
 
@@ -528,7 +529,7 @@ class PdoMap:
             self._task.update(self.data)
 
     def remote_request(self) -> None:
-        """Send a remote request for the transmit PDO.
+        """Send a remote request to transmit PDO.
         Silently ignore if not allowed.
         """
         if self.enabled and self.rtr_allowed:

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -1,15 +1,14 @@
-import struct
-import logging
 import io
-import time
+import logging
 import queue
+import time
 
-from canopen.network import CanError
 from canopen import objectdictionary
+from canopen.network import CanError
 from canopen.sdo.base import SdoBase
-from canopen.utils import pretty_index
 from canopen.sdo.constants import *
 from canopen.sdo.exceptions import *
+from canopen.utils import pretty_index
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +41,7 @@ class SdoClient(SdoBase):
         self.responses = queue.Queue()
 
     def on_response(self, can_id, data, timestamp):
+        _ = can_id, timestamp
         self.responses.put(bytes(data))
 
     def send_request(self, request):
@@ -198,6 +198,7 @@ class SdoClient(SdoBase):
         :returns:
             A file like object.
         """
+        buffered_stream = None
         buffer_size = buffering if buffering > 1 else io.DEFAULT_BUFFER_SIZE
         if "r" in mode:
             if block_transfer:

--- a/canopen/variable.py
+++ b/canopen/variable.py
@@ -24,9 +24,10 @@ class Variable:
         self.subindex = od.subindex
 
     def __repr__(self) -> str:
-        subindex = self.subindex if isinstance(self.od.parent,
-            (objectdictionary.ODRecord, objectdictionary.ODArray)
-        ) else None
+        if isinstance(self.od.parent, (objectdictionary.ODRecord, objectdictionary.ODArray)):
+            subindex = self.subindex
+        else:
+            subindex = None
         return f"<{type(self).__qualname__} {self.name!r} at {pretty_index(self.index, subindex)}>"
 
     def get_data(self) -> bytes:
@@ -148,8 +149,9 @@ class Variable:
         """Alternative way of writing using a function instead of attributes.
 
         May be useful for asynchronous writing.
-
-        :param str fmt:
+        :param value:
+            The value to write
+        :param fmt:
             How to write the value
              - 'raw'
              - 'phys'
@@ -168,6 +170,7 @@ class Bits(Mapping):
     def __init__(self, variable: Variable):
         self.variable = variable
         self.read()
+        self.raw = None
 
     @staticmethod
     def _get_bits(key):

--- a/doc/integration.rst
+++ b/doc/integration.rst
@@ -66,3 +66,4 @@ Here is an example::
     # Should be done in a thread but here we notify the network for
     # demonstration purposes only
     network.notify(0x701, bytearray([0x05]), time.time())
+

--- a/examples/simple_ds402_node.py
+++ b/examples/simple_ds402_node.py
@@ -5,11 +5,11 @@ import traceback
 
 import time
 
+# Start with creating a network representing one CAN bus
+network = canopen.Network()
+
+
 try:
-
-    # Start with creating a network representing one CAN bus
-    network = canopen.Network()
-
     # Connect to the CAN bus
     network.connect(bustype='kvaser', channel=0, bitrate=1000000)
 
@@ -23,7 +23,7 @@ try:
 
     # Reset network
     node.nmt.state = 'RESET COMMUNICATION'
-    #node.nmt.state = 'RESET'
+    # node.nmt.state = 'RESET'
     node.nmt.wait_for_bootup(15)
 
     print(f'node state 1) = {node.nmt.state}')
@@ -77,8 +77,7 @@ try:
     # Save new PDO configuration to node
     node.tpdo.save()
 
-    # publish the a value to the control word (in this case reset the fault at the motors)
-
+    # publish a value to the control word (in this case reset the fault at the motors)
     node.rpdo.read()
     node.rpdo[1]['Controlword'].raw = 0x80
     node.rpdo[1].transmit()
@@ -115,15 +114,12 @@ try:
             raise Exception('Timeout when trying to change state')
         time.sleep(0.001)
 
-    print(f'Node Status {node.powerstate_402.state}')
+    print(f'Node Status {node.state}')
 
     # -----------------------------------------------------------------------------------------
     node.nmt.start_node_guarding(0.01)
     while True:
-        try:
-            network.check()
-        except Exception:
-            break
+        network.check()
 
         # Read a value from TxPDO1
         node.tpdo[1].wait_for_reception()
@@ -141,8 +137,8 @@ except KeyboardInterrupt:
     pass
 except Exception as e:
     exc_type, exc_obj, exc_tb = sys.exc_info()
-    fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-    print(exc_type, fname, exc_tb.tb_lineno)
+    file_name = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+    print(exc_type, file_name, exc_tb.tb_lineno)
     traceback.print_exc()
 finally:
     # Disconnect from CAN bus
@@ -155,4 +151,3 @@ finally:
             node.nmt.stop_node_guarding()
         network.sync.stop()
         network.disconnect()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-can
+setuptools

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -29,7 +29,7 @@ NrOfRXPDO=4
 NrOfTXPDO=4
 LSS_Supported=0
 
-[DeviceComissioning]
+[DeviceCommissioning]
 NodeID=2
 NodeName=Some name
 Baudrate=500

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -157,19 +157,17 @@ class TestEDS(unittest.TestCase):
 
     def test_dummy_variable_undefined(self):
         with self.assertRaises(KeyError):
-            var_undef = self.od['Dummy0001']
+            _ = self.od['Dummy0001']
 
     def test_reading_factor(self):
         var = self.od['EDS file extensions']['FactorAndDescription']
         self.assertEqual(var.factor, 0.1)
         self.assertEqual(var.description, "This is the a test description")
-        self.assertEqual(var.unit,'mV')
+        self.assertEqual(var.unit, 'mV')
         var2 = self.od['EDS file extensions']['Error Factor and No Description']
         self.assertEqual(var2.description, '')
         self.assertEqual(var2.factor, 1)
         self.assertEqual(var2.unit, '')
-
-
 
     def test_comments(self):
         self.assertEqual(self.od.comments,

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -48,6 +48,7 @@ class MockNetwork(object):
     data = None
 
     def send_message(self, can_id, data):
+        _ = can_id
         self.data = data
 
 

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -1,8 +1,8 @@
 import os
-import unittest
-import canopen
-import logging
 import time
+import unittest
+
+import canopen
 
 # logging.basicConfig(level=logging.DEBUG)
 
@@ -17,11 +17,11 @@ class TestSDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
         cls.remote_node2 = cls.network1.add_node(3, EDS_PATH)
@@ -180,11 +180,11 @@ class TestNMT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
         cls.remote_node2 = cls.network1.add_node(3, EDS_PATH)
@@ -214,7 +214,7 @@ class TestNMT(unittest.TestCase):
     def test_stop_two_remote_nodes_using_broadcast(self):
         # This is a NMT broadcast "Stop remote node"
         # ie. set the node in STOPPED state
-        self.network1.send_message(0, [2, 0])
+        self.network1.send_message(0, bytes([2, 0]))
 
         # Line below is just so that we are sure the slaves have received the command
         # before we do the check
@@ -234,6 +234,7 @@ class TestNMT(unittest.TestCase):
 
         self.local_node.nmt.stop_heartbeat()
 
+
 class TestPDO(unittest.TestCase):
     """
     Test PDO slave.
@@ -242,11 +243,11 @@ class TestPDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
     @classmethod

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,9 +1,10 @@
-import time
 import os
+import time
 import unittest
-import canopen
 
 import can
+
+import canopen
 
 EDS_PATH = os.path.join(os.path.dirname(__file__), 'sample.eds')
 
@@ -32,11 +33,11 @@ class TestNetwork(unittest.TestCase):
         self.assertListEqual(self.network.scanner.nodes, [2])
 
     def test_send(self):
-        bus = can.interface.Bus(bustype="virtual", channel=1)
-        self.network.connect(bustype="virtual", channel=1)
+        bus = can.interface.Bus(interface="virtual", channel=1)
+        self.network.connect(interface="virtual", channel=1)
 
         # Send standard ID
-        self.network.send_message(0x123, [1, 2, 3, 4, 5, 6, 7, 8])
+        self.network.send_message(0x123, bytes([1, 2, 3, 4, 5, 6, 7, 8]))
         msg = bus.recv(1)
         self.assertIsNotNone(msg)
         self.assertEqual(msg.arbitration_id, 0x123)
@@ -44,7 +45,7 @@ class TestNetwork(unittest.TestCase):
         self.assertSequenceEqual(msg.data, [1, 2, 3, 4, 5, 6, 7, 8])
 
         # Send extended ID
-        self.network.send_message(0x12345, [])
+        self.network.send_message(0x12345, bytes())
         msg = bus.recv(1)
         self.assertIsNotNone(msg)
         self.assertEqual(msg.arbitration_id, 0x12345)
@@ -54,10 +55,10 @@ class TestNetwork(unittest.TestCase):
         self.network.disconnect()
 
     def test_send_perodic(self):
-        bus = can.interface.Bus(bustype="virtual", channel=1)
-        self.network.connect(bustype="virtual", channel=1)
+        bus = can.interface.Bus(interface="virtual", channel=1)
+        self.network.connect(interface="virtual", channel=1)
 
-        task = self.network.send_periodic(0x123, [1, 2, 3], 0.01)
+        task = self.network.send_periodic(0x123, bytes([1, 2, 3]), 0.01)
         time.sleep(0.1)
         # FIXME: This test is a little fragile, as the number of elements
         #        depends on the timing of the machine.
@@ -67,7 +68,7 @@ class TestNetwork(unittest.TestCase):
         self.assertIsNotNone(msg)
         self.assertSequenceEqual(msg.data, [1, 2, 3])
         # Update data
-        task.update([4, 5, 6])
+        task.update(bytes([4, 5, 6]))
         time.sleep(0.02)
         while msg is not None and msg.data == b'\x01\x02\x03':
             msg = bus.recv(0)

--- a/test/test_od.py
+++ b/test/test_od.py
@@ -151,6 +151,7 @@ class TestObjectDictionary(unittest.TestCase):
         self.assertEqual(test_od["Test Array.Test Variable"], member1)
         self.assertEqual(test_od["Test Array.Test Variable 2"], member2)
 
+
 class TestArray(unittest.TestCase):
 
     def test_subindexes(self):

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -9,32 +9,32 @@ class TestPDO(unittest.TestCase):
 
     def test_bit_mapping(self):
         node = canopen.Node(1, EDS_PATH)
-        map = node.pdo.tx[1]
-        map.add_variable('INTEGER16 value')  # 0x2001
-        map.add_variable('UNSIGNED8 value', length=4)  # 0x2002
-        map.add_variable('INTEGER8 value', length=4)  # 0x2003
-        map.add_variable('INTEGER32 value')  # 0x2004
-        map.add_variable('BOOLEAN value', length=1)  # 0x2005
-        map.add_variable('BOOLEAN value 2', length=1)  # 0x2006
+        test_map = node.pdo.tx[1]
+        test_map.add_variable('INTEGER16 value')  # 0x2001
+        test_map.add_variable('UNSIGNED8 value', length=4)  # 0x2002
+        test_map.add_variable('INTEGER8 value', length=4)  # 0x2003
+        test_map.add_variable('INTEGER32 value')  # 0x2004
+        test_map.add_variable('BOOLEAN value', length=1)  # 0x2005
+        test_map.add_variable('BOOLEAN value 2', length=1)  # 0x2006
 
         # Write some values
-        map['INTEGER16 value'].raw = -3
-        map['UNSIGNED8 value'].raw = 0xf
-        map['INTEGER8 value'].raw = -2
-        map['INTEGER32 value'].raw = 0x01020304
-        map['BOOLEAN value'].raw = False
-        map['BOOLEAN value 2'].raw = True
+        test_map['INTEGER16 value'].raw = -3
+        test_map['UNSIGNED8 value'].raw = 0xf
+        test_map['INTEGER8 value'].raw = -2
+        test_map['INTEGER32 value'].raw = 0x01020304
+        test_map['BOOLEAN value'].raw = False
+        test_map['BOOLEAN value 2'].raw = True
 
         # Check expected data
-        self.assertEqual(map.data, b'\xfd\xff\xef\x04\x03\x02\x01\x02')
+        self.assertEqual(test_map.data, b'\xfd\xff\xef\x04\x03\x02\x01\x02')
 
         # Read values from data
-        self.assertEqual(map['INTEGER16 value'].raw, -3)
-        self.assertEqual(map['UNSIGNED8 value'].raw, 0xf)
-        self.assertEqual(map['INTEGER8 value'].raw, -2)
-        self.assertEqual(map['INTEGER32 value'].raw, 0x01020304)
-        self.assertEqual(map['BOOLEAN value'].raw, False)
-        self.assertEqual(map['BOOLEAN value 2'].raw, True)
+        self.assertEqual(test_map['INTEGER16 value'].raw, -3)
+        self.assertEqual(test_map['UNSIGNED8 value'].raw, 0xf)
+        self.assertEqual(test_map['INTEGER8 value'].raw, -2)
+        self.assertEqual(test_map['INTEGER32 value'].raw, 0x01020304)
+        self.assertEqual(test_map['BOOLEAN value'].raw, False)
+        self.assertEqual(test_map['BOOLEAN value 2'].raw, True)
 
         self.assertEqual(node.tpdo[1]['INTEGER16 value'].raw, -3)
         self.assertEqual(node.tpdo[1]['UNSIGNED8 value'].raw, 0xf)

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -110,8 +110,7 @@ class TestSDO(unittest.TestCase):
             (RX, b'\xa1\x00\x00\x00\x00\x00\x00\x00')
         ]
         data = b'A really really long string...'
-        with self.network[2].sdo['Writable string'].open(
-            'wb', size=len(data), block_transfer=True) as fp:
+        with self.network[2].sdo['Writable string'].open('wb', size=len(data), block_transfer=True) as fp:
             fp.write(data)
 
     def test_block_upload(self):

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -1,13 +1,15 @@
 import unittest
+
 import canopen
+from canopen.sync import SyncProducer
 
 
 class TestSync(unittest.TestCase):
 
     def test_sync_producer(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
-        producer = canopen.sync.SyncProducer(network)
+        network.connect(interface="virtual", receive_own_messages=True)
+        producer = SyncProducer(network)
         producer.transmit()
         msg = network.bus.recv(1)
         network.disconnect()
@@ -16,14 +18,15 @@ class TestSync(unittest.TestCase):
 
     def test_sync_producer_counter(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
-        producer = canopen.sync.SyncProducer(network)
+        network.connect(interface="virtual", receive_own_messages=True)
+        producer = SyncProducer(network)
         producer.transmit(2)
         msg = network.bus.recv(1)
         network.disconnect()
         self.assertEqual(msg.arbitration_id, 0x80)
         self.assertEqual(msg.dlc, 1)
         self.assertEqual(msg.data, b"\x02")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -1,13 +1,15 @@
 import unittest
+
 import canopen
+from canopen.timestamp import TimeProducer
 
 
 class TestTime(unittest.TestCase):
 
     def test_time_producer(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
-        producer = canopen.timestamp.TimeProducer(network)
+        network.connect(interface="virtual", receive_own_messages=True)
+        producer = TimeProducer(network)
         producer.transmit(1486236238)
         msg = network.bus.recv(1)
         network.disconnect()


### PR DESCRIPTION
Fixed a lot of small things, I know this is a nightmare to review, but we would go crazy if we open 20 pull requests, right?

the only functional changes are:

    def send_switch_state_selective(self, vendor_id, product_code, revision_number, serial_number)

I changed the signature of the method, upperCase is not allowed according to PEP8.

     def connect(self, channel=None, interface=None, **kwargs)

I also changed this signature, to resemble the signature of the can.Bus class. If you are using the old bustype argument, you will get a warning that you use both, the old and the new "interface" together.

If you don't like this change, we can find another solution. In the beginning the docstring was old and wrong.

    