### PR TITLE
Export PdoMap and PdoVariable classes in pdo module

### DIFF
--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,10 +1,18 @@
 import logging
 
 from canopen import node
-from canopen.pdo.base import PdoBase, PdoMaps
+from canopen.pdo.base import PdoBase, PdoMap, PdoMaps, PdoVariable
 
-# Compatibility
-from canopen.pdo.base import Variable
+
+__all__ = [
+    "PdoBase",
+    "PdoMap",
+    "PdoMaps",
+    "PdoVariable",
+    "PDO",
+    "RPDO",
+    "TPDO",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -77,3 +85,7 @@ class TPDO(PdoBase):
                 pdo.stop()
         else:
             raise TypeError('The node type does not support this function.')
+
+
+# Compatibility
+Variable = PdoVariable

--- a/canopen/profiles/p402.py
+++ b/canopen/profiles/p402.py
@@ -1,8 +1,10 @@
 # inspired by the NmtMaster code
 import logging
 import time
+from typing import Dict
 
 from canopen.node import RemoteNode
+from canopen.pdo import PdoMap
 from canopen.sdo import SdoCommunicationError
 
 logger = logging.getLogger(__name__)
@@ -212,8 +214,8 @@ class BaseNode402(RemoteNode):
     def __init__(self, node_id, object_dictionary):
         super(BaseNode402, self).__init__(node_id, object_dictionary)
         self.tpdo_values = {}  # { index: value from last received TPDO }
-        self.tpdo_pointers = {}  # { index: pdo.PdoMap instance }
-        self.rpdo_pointers = {}  # { index: pdo.PdoMap instance }
+        self.tpdo_pointers: Dict[int, PdoMap] = {}
+        self.rpdo_pointers: Dict[int, PdoMap] = {}
 
     def setup_402_state_machine(self, read_pdos=True):
         """Configure the state machine by searching for a TPDO that has the StatusWord mapped.
@@ -453,11 +455,10 @@ class BaseNode402(RemoteNode):
         bits = OperationMode.SUPPORTED[mode]
         return self._op_mode_support & bits == bits
 
-    def on_TPDOs_update_callback(self, mapobject):
+    def on_TPDOs_update_callback(self, mapobject: PdoMap):
         """Cache updated values from a TPDO received from this node.
 
         :param mapobject: The received PDO message.
-        :type mapobject: canopen.pdo.PdoMap
         """
         for obj in mapobject:
             self.tpdo_values[obj.index] = obj.raw


### PR DESCRIPTION
With commit 0285f582beb344de708ce8308274a99bc04988a1, the `Map` class was inadvertently removed from the imports directly available within the `canopen.pdo` package.  However, it is referenced as `canopen.pdo.PdoMap` in the `p402` module and documentation.

Restore that import using the new names `PdoMap` and `PdoVariable`.  Move the compatibility define to the very bottom, just like in other modules.  Provide an `__all__` listing to clarify what constitutes the public API.