### PR TITLE
build: Explicitly specify packages to install (fixes #467)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ target/
 
 *.kdev4
 *.kate-swp
+
+# Virtual environments
+venv*/

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,3 @@ target/
 
 *.kdev4
 *.kate-swp
-
-# Virtual environments
-venv*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dynamic = ["version"]
 documentation = "https://canopen.readthedocs.io/en/stable/"
 repository = "https://github.com/christiansandberg/canopen"
 
+[tool.setuptools]
+packages = ["canopen"]
+
 [tool.setuptools_scm]
 version_file = "canopen/_version.py"
 


### PR DESCRIPTION
This PR fixes #467 when trying to install canopen with an virtual environment inside the source tree.