### PR TITLE
Bail early if an unsupported doctype is passed to export_od()

### DIFF
--- a/canopen/objectdictionary/__init__.py
+++ b/canopen/objectdictionary/__init__.py
@@ -37,13 +37,19 @@ def export_od(
     :raises ValueError:
         When exporting to an unknown format.
     """
+    supported_doctypes = {"eds", "dcf"}
+    if doc_type and doc_type not in supported_doctypes:
+        supported = ", ".join(supported_doctypes)
+        raise ValueError(
+            f"Cannot export to the {doc_type!r} format; "
+            f"supported formats: {supported}"
+        )
 
     opened_here = False
     try:
-        doctypes = {"eds", "dcf"}
         if isinstance(dest, str):
             if doc_type is None:
-                for t in doctypes:
+                for t in supported_doctypes:
                     if dest.endswith(f".{t}"):
                         doc_type = t
                         break
@@ -58,12 +64,6 @@ def export_od(
         elif doc_type == "dcf":
             from canopen.objectdictionary import eds
             return eds.export_dcf(od, dest)
-        else:
-            allowed = ", ".join(doctypes)
-            raise ValueError(
-                f"Cannot export to the {doc_type!r} format; "
-                f"supported formats: {allowed}"
-            )
     finally:
         # If dest is opened in this fn, it should be closed
         if opened_here:

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -222,11 +222,14 @@ class TestEDS(unittest.TestCase):
         import io
         filelike_object = io.StringIO()
         self.addCleanup(filelike_object.close)
-        self.addCleanup(os.unlink, "filename")
         for dest in "filename", None, filelike_object:
             with self.subTest(dest=dest):
                 with self.assertRaisesRegex(ValueError, "'unknown'"):
                     canopen.export_od(self.od, dest, doc_type="unknown")
+                # Make sure no files are created is a filename is supplied.
+                if isinstance(dest, str):
+                    with self.assertRaises(FileNotFoundError):
+                        os.stat(dest)
 
     def test_export_eds_to_filelike_object(self):
         import io


### PR DESCRIPTION
Fixes #485
