### PR TITLE
Adapt to renamed "bustype" parameter on can.Bus

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,12 +107,12 @@ The :code:`n` is the PDO index (normally 1 to 4). The second form of access is f
     # Arguments are passed to python-can's can.Bus() constructor
     # (see https://python-can.readthedocs.io/en/latest/bus.html).
     network.connect()
-    # network.connect(bustype='socketcan', channel='can0')
-    # network.connect(bustype='kvaser', channel=0, bitrate=250000)
-    # network.connect(bustype='pcan', channel='PCAN_USBBUS1', bitrate=250000)
-    # network.connect(bustype='ixxat', channel=0, bitrate=250000)
-    # network.connect(bustype='vector', app_name='CANalyzer', channel=0, bitrate=250000)
-    # network.connect(bustype='nican', channel='CAN0', bitrate=250000)
+    # network.connect(interface='socketcan', channel='can0')
+    # network.connect(interface='kvaser', channel=0, bitrate=250000)
+    # network.connect(interface='pcan', channel='PCAN_USBBUS1', bitrate=250000)
+    # network.connect(interface='ixxat', channel=0, bitrate=250000)
+    # network.connect(interface='vector', app_name='CANalyzer', channel=0, bitrate=250000)
+    # network.connect(interface='nican', channel='CAN0', bitrate=250000)
 
     # Read a variable using SDO
     device_name = node.sdo['Manufacturer device name'].raw

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -92,7 +92,7 @@ class Network(MutableMapping):
 
         :param channel:
             Backend specific channel for the CAN interface.
-        :param str bustype:
+        :param str interface:
             Name of the interface. See
             `python-can manual <https://python-can.readthedocs.io/en/stable/configuration.html#interface-names>`__
             for full list of supported interfaces.

--- a/doc/network.rst
+++ b/doc/network.rst
@@ -25,11 +25,11 @@ See its documentation for specifics on how to configure your specific interface.
 Call the :meth:`~canopen.Network.connect` method to start the communication, optionally providing
 arguments passed to a the :class:`can.BusABC` constructor::
 
-    network.connect(channel='can0', bustype='socketcan')
-    # network.connect(bustype='kvaser', channel=0, bitrate=250000)
-    # network.connect(bustype='pcan', channel='PCAN_USBBUS1', bitrate=250000)
-    # network.connect(bustype='ixxat', channel=0, bitrate=250000)
-    # network.connect(bustype='nican', channel='CAN0', bitrate=250000)
+    network.connect(channel='can0', interface='socketcan')
+    # network.connect(interface='kvaser', channel=0, bitrate=250000)
+    # network.connect(interface='pcan', channel='PCAN_USBBUS1', bitrate=250000)
+    # network.connect(interface='ixxat', channel=0, bitrate=250000)
+    # network.connect(interface='nican', channel='CAN0', bitrate=250000)
 
 Add nodes to the network using the :meth:`~canopen.Network.add_node` method::
 

--- a/examples/simple_ds402_node.py
+++ b/examples/simple_ds402_node.py
@@ -11,7 +11,7 @@ try:
     network = canopen.Network()
 
     # Connect to the CAN bus
-    network.connect(bustype='kvaser', channel=0, bitrate=1000000)
+    network.connect(interface='kvaser', channel=0, bitrate=1000000)
 
     network.check()
 

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -17,11 +17,11 @@ class TestSDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
         cls.remote_node2 = cls.network1.add_node(3, EDS_PATH)
@@ -180,11 +180,11 @@ class TestNMT(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
         cls.remote_node2 = cls.network1.add_node(3, EDS_PATH)
@@ -242,11 +242,11 @@ class TestPDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
-        cls.network1.connect("test", bustype="virtual")
+        cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, EDS_PATH)
 
         cls.network2 = canopen.Network()
-        cls.network2.connect("test", bustype="virtual")
+        cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, EDS_PATH)
 
     @classmethod

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -32,8 +32,8 @@ class TestNetwork(unittest.TestCase):
         self.assertListEqual(self.network.scanner.nodes, [2])
 
     def test_send(self):
-        bus = can.interface.Bus(bustype="virtual", channel=1)
-        self.network.connect(bustype="virtual", channel=1)
+        bus = can.interface.Bus(interface="virtual", channel=1)
+        self.network.connect(interface="virtual", channel=1)
 
         # Send standard ID
         self.network.send_message(0x123, [1, 2, 3, 4, 5, 6, 7, 8])
@@ -54,8 +54,8 @@ class TestNetwork(unittest.TestCase):
         self.network.disconnect()
 
     def test_send_perodic(self):
-        bus = can.interface.Bus(bustype="virtual", channel=1)
-        self.network.connect(bustype="virtual", channel=1)
+        bus = can.interface.Bus(interface="virtual", channel=1)
+        self.network.connect(interface="virtual", channel=1)
 
         task = self.network.send_periodic(0x123, [1, 2, 3], 0.01)
         time.sleep(0.1)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -6,7 +6,7 @@ class TestSync(unittest.TestCase):
 
     def test_sync_producer(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
+        network.connect(interface="virtual", receive_own_messages=True)
         producer = canopen.sync.SyncProducer(network)
         producer.transmit()
         msg = network.bus.recv(1)
@@ -16,7 +16,7 @@ class TestSync(unittest.TestCase):
 
     def test_sync_producer_counter(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
+        network.connect(interface="virtual", receive_own_messages=True)
         producer = canopen.sync.SyncProducer(network)
         producer.transmit(2)
         msg = network.bus.recv(1)

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -6,7 +6,7 @@ class TestTime(unittest.TestCase):
 
     def test_time_producer(self):
         network = canopen.Network()
-        network.connect(bustype="virtual", receive_own_messages=True)
+        network.connect(interface="virtual", receive_own_messages=True)
         producer = canopen.timestamp.TimeProducer(network)
         producer.transmit(1486236238)
         msg = network.bus.recv(1)


### PR DESCRIPTION
The bustype keyword has long been replaced by "interface" and the former is deprecated in python-can.  The Network class passes it through without caring for the name, but documentation and tests referred to the older name regularly.

Based on discussion in #487.