### PR TITLE
Restrict python-can to major versions 3 and 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "python-can >= 3.0.0",
+    "python-can >= 3.0.0, <5",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Resolves #487
