### PR TITLE
Gracefully handle missing Baudrate setting in DCF

### DIFF
--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -85,7 +85,8 @@ def import_eds(source, node_id):
                 pass
 
     if eds.has_section("DeviceComissioning"):
-        od.bitrate = int(eds.get("DeviceComissioning", "Baudrate")) * 1000
+        if val := eds.get("DeviceComissioning", "Baudrate", fallback=None):
+            od.bitrate = int(val) * 1000
 
         if node_id is None:
             if val := eds.get("DeviceComissioning", "NodeID", fallback=None):


### PR DESCRIPTION
The CiA306 spec is not quite clear on which fields are mandatory within the DeviceComissioning section.  Thus it should be assumed that the two options handled here could be missing.  Instead of raising an exception, ignore the absence of the Baudrate setting.