### PR TITLE
Ensure NmtBase.state always returns a string

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -86,10 +86,10 @@ class NmtBase:
         - 'RESET'
         - 'RESET COMMUNICATION'
         """
-        if self._state in NMT_STATES:
+        try:
             return NMT_STATES[self._state]
-        else:
-            return self._state
+        except KeyError:
+            return f"UNKNOWN STATE '{self._state}'"
 
     @state.setter
     def state(self, new_state: str):

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -92,7 +92,7 @@ class TestNmtMaster(unittest.TestCase):
         task = self.net.send_periodic(self.COB_ID, [0xcb], self.PERIOD)
         self.addCleanup(task.stop)
         state = self.node.nmt.wait_for_heartbeat(self.TIMEOUT)
-        # Expect the high bit to be masked out, and and unknown state string to
+        # Expect the high bit to be masked out, and a formatted string to
         # be returned.
         self.assertEqual(state, "UNKNOWN STATE '75'")
 

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -88,7 +88,6 @@ class TestNmtMaster(unittest.TestCase):
         state = self.node.nmt.wait_for_heartbeat(self.TIMEOUT)
         self.assertEqual(state, "PRE-OPERATIONAL")
 
-    @unittest.expectedFailure
     def test_nmt_master_on_heartbeat_unknown_state(self):
         task = self.net.send_periodic(self.COB_ID, [0xcb], self.PERIOD)
         self.addCleanup(task.stop)


### PR DESCRIPTION
Fixes #500
