### PR TITLE
Tests: harden TestNetwork and TestNmt even more

### DIFF
--- a/canopen/nmt.py
+++ b/canopen/nmt.py
@@ -86,10 +86,10 @@ class NmtBase:
         - 'RESET'
         - 'RESET COMMUNICATION'
         """
-        if self._state in NMT_STATES:
+        try:
             return NMT_STATES[self._state]
-        else:
-            return self._state
+        except KeyError:
+            return f"UNKNOWN STATE '{self._state}'"
 
     @state.setter
     def state(self, new_state: str):

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -93,7 +93,7 @@ class TestNetwork(unittest.TestCase):
             condition.wait_for(periodicity, TIMEOUT)
         self.assertTrue(all(v[0] == DATA1 for v in acc))
 
-        # Update task data, which implicitly restarts the timer.
+        # Update task data, which may implicitly restart the timer.
         # Wait for frames to arrive; then check the result.
         task.update(DATA2)
         with condition:

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -69,9 +69,10 @@ class TestNetwork(unittest.TestCase):
         condition = threading.Condition()
 
         def hook(_, data, ts):
-            item = data, ts
-            acc.append(item)
-            condition.notify()
+            with condition:
+                item = data, ts
+                acc.append(item)
+                condition.notify_all()
 
         self.network.subscribe(COB_ID, hook)
         self.addCleanup(self.network.unsubscribe, COB_ID)

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -106,7 +106,12 @@ class TestNetwork(unittest.TestCase):
 
         # Stop the task.
         task.stop()
-        self.assertIsNone(self.network.bus.recv(TIMEOUT))
+        # A message may have been in flight when we stopped the timer,
+        # so allow a single failure.
+        bus = self.network.bus
+        msg = bus.recv(TIMEOUT)
+        if msg:
+            self.assertIsNone(bus.recv(TIMEOUT))
 
 
 class TestScanner(unittest.TestCase):

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -88,12 +88,11 @@ class TestNmtMaster(unittest.TestCase):
         state = self.node.nmt.wait_for_heartbeat(self.TIMEOUT)
         self.assertEqual(state, "PRE-OPERATIONAL")
 
-    @unittest.expectedFailure
     def test_nmt_master_on_heartbeat_unknown_state(self):
         task = self.net.send_periodic(self.COB_ID, [0xcb], self.PERIOD)
         self.addCleanup(task.stop)
         state = self.node.nmt.wait_for_heartbeat(self.TIMEOUT)
-        # Expect the high bit to be masked out, and and unknown state string to
+        # Expect the high bit to be masked out, and a formatted string to
         # be returned.
         self.assertEqual(state, "UNKNOWN STATE '75'")
 

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -117,7 +117,11 @@ class TestNmtMaster(unittest.TestCase):
         self.assertEqual(msg.dlc, 0)
 
         self.node.nmt.stop_node_guarding()
-        self.assertIsNone(self.bus.recv(self.TIMEOUT))
+        # A message may have been in flight when we stopped the timer,
+        # so allow a single failure.
+        msg = self.bus.recv(self.TIMEOUT)
+        if msg:
+            self.assertIsNone(self.bus.recv(self.TIMEOUT))
 
 
 class TestNmtSlave(unittest.TestCase):


### PR DESCRIPTION
- test task.stop()
- use more lenient timeout
- ~~make sure we always collect two frames~~

See commit messages for details.
