### PR TITLE
Annotate Network and check usage of it runtime

### DIFF
--- a/canopen/emcy.py
+++ b/canopen/emcy.py
@@ -2,7 +2,10 @@ import struct
 import logging
 import threading
 import time
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 # Error code, error register, vendor specific data
 EMCY_STRUCT = struct.Struct("<HB5s")
@@ -82,14 +85,18 @@ class EmcyConsumer:
 class EmcyProducer:
 
     def __init__(self, cob_id: int):
-        self.network = None
+        self.network: Optional[Network] = None
         self.cob_id = cob_id
 
     def send(self, code: int, register: int = 0, data: bytes = b""):
+        if self.network is None:
+            raise RuntimeError("A Network is required")
         payload = EMCY_STRUCT.pack(code, register, data)
         self.network.send_message(self.cob_id, payload)
 
     def reset(self, register: int = 0, data: bytes = b""):
+        if self.network is None:
+            raise RuntimeError("A Network is required to reset")
         payload = EMCY_STRUCT.pack(0, register, data)
         self.network.send_message(self.cob_id, payload)
 

--- a/canopen/lss.py
+++ b/canopen/lss.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 import logging
 import time
 import struct
 import queue
+
+if TYPE_CHECKING:
+    from canopen.network import Network
+
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +85,7 @@ class LssMaster:
     RESPONSE_TIMEOUT = 0.5
 
     def __init__(self):
-        self.network = None
+        self.network: Optional[Network] = None
         self._node_id = 0
         self._data = None
         self.responses = queue.Queue()
@@ -375,6 +381,8 @@ class LssMaster:
             logger.info("There were unexpected messages in the queue")
             self.responses = queue.Queue()
 
+        if self.network is None:
+            raise RuntimeError("A Network is required to do send messages")
         self.network.send_message(self.LSS_TX_COBID, message)
 
         if not bool(message[0] in ListMessageNeedResponse):

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -350,7 +350,7 @@ class MessageListener(Listener):
     """
 
     def __init__(self, network: Network):
-        self.network = network
+        self.network: Network = network
 
     def on_message_received(self, msg):
         if msg.is_error_frame or msg.is_remote_frame:
@@ -385,7 +385,7 @@ class NodeScanner:
     SERVICES = (0x700, 0x580, 0x180, 0x280, 0x380, 0x480, 0x80)
 
     def __init__(self, network: Optional[Network] = None):
-        self.network = network
+        self.network: Optional[Network] = network
         #: A :class:`list` of nodes discovered
         self.nodes: List[int] = []
 

--- a/canopen/node/base.py
+++ b/canopen/node/base.py
@@ -1,5 +1,8 @@
-from typing import TextIO, Union
+from typing import TextIO, Union, Optional, TYPE_CHECKING
 from canopen.objectdictionary import ObjectDictionary, import_od
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 
 class BaseNode:
@@ -17,7 +20,7 @@ class BaseNode:
         node_id: int,
         object_dictionary: Union[ObjectDictionary, str, TextIO],
     ):
-        self.network = None
+        self.network: Optional[Network] = None
 
         if not isinstance(object_dictionary, ObjectDictionary):
             object_dictionary = import_od(object_dictionary, node_id)

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 import logging
-from typing import Dict, Union
+from typing import Dict, Union, TYPE_CHECKING
 
 from canopen.node.base import BaseNode
 from canopen.sdo import SdoServer, SdoAbortedError
@@ -8,6 +9,9 @@ from canopen.nmt import NmtSlave
 from canopen.emcy import EmcyProducer
 from canopen.objectdictionary import ObjectDictionary
 from canopen import objectdictionary
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +38,7 @@ class LocalNode(BaseNode):
         self.add_write_callback(self.nmt.on_write)
         self.emcy = EmcyProducer(0x80 + self.id)
 
-    def associate_network(self, network):
+    def associate_network(self, network: Network):
         self.network = network
         self.sdo.network = network
         self.tpdo.network = network
@@ -45,8 +49,9 @@ class LocalNode(BaseNode):
         network.subscribe(0, self.nmt.on_command)
 
     def remove_network(self):
-        self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)
-        self.network.unsubscribe(0, self.nmt.on_command)
+        if self.network is not None:
+            self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)
+            self.network.unsubscribe(0, self.nmt.on_command)
         self.network = None
         self.sdo.network = None
         self.tpdo.network = None

--- a/canopen/objectdictionary/eds.py
+++ b/canopen/objectdictionary/eds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
 import copy
 import logging
 import re
@@ -6,6 +8,9 @@ from configparser import RawConfigParser, NoOptionError, NoSectionError
 from canopen import objectdictionary
 from canopen.objectdictionary import ObjectDictionary, datatypes
 from canopen.sdo import SdoClient
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +177,7 @@ def import_eds(source, node_id):
     return od
 
 
-def import_from_node(node_id, network):
+def import_from_node(node_id, network: Network):
     """ Download the configuration from the remote node
     :param int node_id: Identifier of the node
     :param network: network object

--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -464,6 +464,8 @@ class PdoMap:
         known to match what's stored on the node.
         """
         if self.enabled:
+            if self.pdo_node.network is None:
+               raise RuntimeError("A Network is required")
             logger.info("Subscribing to enabled PDO 0x%X on the network", self.cob_id)
             self.pdo_node.network.subscribe(self.cob_id, self.on_message)
 
@@ -511,6 +513,8 @@ class PdoMap:
 
     def transmit(self) -> None:
         """Transmit the message once."""
+        if self.pdo_node.network is None:
+            raise RuntimeError("A Network is required")
         self.pdo_node.network.send_message(self.cob_id, self.data)
 
     def start(self, period: Optional[float] = None) -> None:
@@ -521,6 +525,9 @@ class PdoMap:
             on the object before.
         :raises ValueError: When neither the argument nor the :attr:`period` is given.
         """
+        if self.pdo_node.network is None:
+            raise RuntimeError("A Network is required")
+
         # Stop an already running transmission if we have one, otherwise we
         # overwrite the reference and can lose our handle to shut it down
         self.stop()
@@ -551,6 +558,8 @@ class PdoMap:
         Silently ignore if not allowed.
         """
         if self.enabled and self.rtr_allowed:
+            if self.pdo_node.network is None:
+                raise RuntimeError("A Network is required")
             self.pdo_node.network.send_message(self.cob_id, bytes(), remote=True)
 
     def wait_for_reception(self, timeout: float = 10) -> float:

--- a/canopen/sdo/base.py
+++ b/canopen/sdo/base.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import binascii
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional, Union, TYPE_CHECKING
 from collections.abc import Mapping
 
 from canopen import objectdictionary
 from canopen import variable
 from canopen.utils import pretty_index
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 
 class CrcXmodem:
@@ -43,7 +46,7 @@ class SdoBase(Mapping):
         """
         self.rx_cobid = rx_cobid
         self.tx_cobid = tx_cobid
-        self.network = None
+        self.network: Optional[Network] = None
         self.od = od
 
     def __getitem__(

--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -45,6 +45,8 @@ class SdoClient(SdoBase):
         self.responses.put(bytes(data))
 
     def send_request(self, request):
+        if self.network is None:
+            raise RuntimeError("A Network is required to send a request")
         retries_left = self.MAX_RETRIES
         if self.PAUSE_BEFORE_SEND:
             time.sleep(self.PAUSE_BEFORE_SEND)

--- a/canopen/sdo/server.py
+++ b/canopen/sdo/server.py
@@ -172,6 +172,8 @@ class SdoServer(SdoBase):
         self.send_response(response)
 
     def send_response(self, response):
+        if self.network is None:
+            raise RuntimeError("A Network is required to send")
         self.network.send_message(self.tx_cobid, response)
 
     def abort(self, abort_code=0x08000000):

--- a/canopen/sync.py
+++ b/canopen/sync.py
@@ -1,4 +1,8 @@
-from typing import Optional
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from canopen.network import Network
 
 
 class SyncProducer:
@@ -7,8 +11,8 @@ class SyncProducer:
     #: COB-ID of the SYNC message
     cob_id = 0x80
 
-    def __init__(self, network):
-        self.network = network
+    def __init__(self, network: Network):
+        self.network: Network = network
         self.period: Optional[float] = None
         self._task = None
 

--- a/canopen/timestamp.py
+++ b/canopen/timestamp.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 import time
 import struct
-from typing import Optional
+
+if TYPE_CHECKING:
+    from canopen.network import Network
+
 
 # 1 Jan 1984
 OFFSET = 441763200
@@ -16,8 +21,8 @@ class TimeProducer:
     #: COB-ID of the SYNC message
     cob_id = 0x100
 
-    def __init__(self, network):
-        self.network = network
+    def __init__(self, network: Network):
+        self.network: Network = network
 
     def transmit(self, timestamp: Optional[float] = None):
         """Send out the TIME message once.


### PR DESCRIPTION
With reference to #511 this PR properly annotates all uses of `Network` and adds runtime checks for the usage of `Network` instances. In very many classes `self.network` is `Optional[Network]` with default `None` and thus a runtime check is needed for it being set properly.
