### PR TITLE
CI: Add requirements-dev.txt and add pip cache

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,9 +5,17 @@ name: Python package
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+    - 'master'
+    paths-ignore:
+    - 'README.rst'
+    - 'LICENSE.txt'
   pull_request:
-    branches: [ "master" ]
+    branches:
+    - 'master'
+    paths-ignore:
+    - 'README.rst'
+    - 'LICENSE.txt'
 
 jobs:
   build:
@@ -20,19 +28,19 @@ jobs:
         features: ['', '[db_export]']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          'pyproject.toml'
+          'requirements-dev.txt'
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        pip install -e '.${{ matrix.features }}'
+      run: python3 -m pip install -e '.${{ matrix.features }}' -r requirements-dev.txt
     - name: Test with pytest
-      run: |
-        pytest -v --cov=canopen --cov-report=xml --cov-branch
+      run: pytest -v --cov=canopen --cov-report=xml --cov-branch
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ it in `develop mode`_::
 
 Unit tests can be run using the pytest_ framework::
 
-    $ pip install pytest
+    $ pip install -r requirements-dev.txt
     $ pytest -v
 
 You can also use :mod:`unittest` standard library module::

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest~=8.3
+pytest-cov~=5.0


### PR DESCRIPTION
Also:
- bump GitHub checkout action to v4
- bump GitHub setup-python action to v5
- ignore README and LICENSE files
- invoke pip according to best practise

Follow-up of #498