### PR TITLE
Make Network.notifier timeouts customizable (fixes #530)

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -25,8 +25,8 @@ Callback = Callable[[int, bytearray, float], None]
 class Network(MutableMapping):
     """Representation of one CAN bus containing one or more nodes."""
 
-    NOTIFIER_CYCLE: float = 1.0  #: Maximum waiting time for one notifier iteration
-    NOTIFIER_SHUTDOWN_TIMEOUT: float = 5.0  #: Maximum waiting time to stop notifiers
+    NOTIFIER_CYCLE: float = 1.0  #: Maximum waiting time for one notifier iteration.
+    NOTIFIER_SHUTDOWN_TIMEOUT: float = 5.0  #: Maximum waiting time to stop notifiers.
 
     def __init__(self, bus: Optional[can.BusABC] = None):
         """

--- a/canopen/network.py
+++ b/canopen/network.py
@@ -25,6 +25,9 @@ Callback = Callable[[int, bytearray, float], None]
 class Network(MutableMapping):
     """Representation of one CAN bus containing one or more nodes."""
 
+    NOTIFIER_CYCLE: float = 1.0  #: Maximum waiting time for one notifier iteration
+    NOTIFIER_SHUTDOWN_TIMEOUT: float = 5.0  #: Maximum waiting time to stop notifiers
+
     def __init__(self, bus: Optional[can.BusABC] = None):
         """
         :param can.BusABC bus:
@@ -105,7 +108,7 @@ class Network(MutableMapping):
         if self.bus is None:
             self.bus = can.Bus(*args, **kwargs)
         logger.info("Connected to '%s'", self.bus.channel_info)
-        self.notifier = can.Notifier(self.bus, self.listeners, 1)
+        self.notifier = can.Notifier(self.bus, self.listeners, self.NOTIFIER_CYCLE)
         return self
 
     def disconnect(self) -> None:
@@ -117,7 +120,7 @@ class Network(MutableMapping):
             if hasattr(node, "pdo"):
                 node.pdo.stop()
         if self.notifier is not None:
-            self.notifier.stop()
+            self.notifier.stop(self.NOTIFIER_SHUTDOWN_TIMEOUT)
         if self.bus is not None:
             self.bus.shutdown()
         self.bus = None

--- a/test/test_emcy.py
+++ b/test/test_emcy.py
@@ -185,6 +185,7 @@ class TestEmcyProducer(unittest.TestCase):
         self.txbus = can.Bus(interface="virtual")
         self.rxbus = can.Bus(interface="virtual")
         self.net = canopen.Network(self.txbus)
+        self.net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         self.net.connect()
         self.emcy = canopen.emcy.EmcyProducer(0x80 + 1)
         self.emcy.network = self.net

--- a/test/test_local.py
+++ b/test/test_local.py
@@ -13,10 +13,12 @@ class TestSDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
+        cls.network1.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, SAMPLE_EDS)
 
         cls.network2 = canopen.Network()
+        cls.network2.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, SAMPLE_EDS)
 
@@ -176,10 +178,12 @@ class TestPDO(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.network1 = canopen.Network()
+        cls.network1.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network1.connect("test", interface="virtual")
         cls.remote_node = cls.network1.add_node(2, SAMPLE_EDS)
 
         cls.network2 = canopen.Network()
+        cls.network2.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         cls.network2.connect("test", interface="virtual")
         cls.local_node = cls.network2.create_node(2, SAMPLE_EDS)
 

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -11,6 +11,7 @@ class TestNetwork(unittest.TestCase):
 
     def setUp(self):
         self.network = canopen.Network()
+        self.network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
 
     def test_network_add_node(self):
         # Add using str.
@@ -328,6 +329,7 @@ class TestScanner(unittest.TestCase):
         self.addCleanup(txbus.shutdown)
 
         net = canopen.Network(txbus)
+        net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         net.connect()
         self.addCleanup(net.disconnect)
 
@@ -347,6 +349,7 @@ class TestScanner(unittest.TestCase):
     def test_scanner_search_limit(self):
         bus = can.Bus(interface="virtual", receive_own_messages=True)
         net = canopen.Network(bus)
+        net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         net.connect()
         self.addCleanup(net.disconnect)
 

--- a/test/test_nmt.py
+++ b/test/test_nmt.py
@@ -52,6 +52,7 @@ class TestNmtMaster(unittest.TestCase):
             receive_own_messages=True,
         )
         net = canopen.Network(bus)
+        net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         net.connect()
         with self.assertLogs():
             node = net.add_node(self.NODE_ID, SAMPLE_EDS)
@@ -127,11 +128,13 @@ class TestNmtMaster(unittest.TestCase):
 class TestNmtSlave(unittest.TestCase):
     def setUp(self):
         self.network1 = canopen.Network()
+        self.network1.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         self.network1.connect("test", interface="virtual")
         with self.assertLogs():
             self.remote_node = self.network1.add_node(2, SAMPLE_EDS)
 
         self.network2 = canopen.Network()
+        self.network2.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         self.network2.connect("test", interface="virtual")
         with self.assertLogs():
             self.local_node = self.network2.create_node(2, SAMPLE_EDS)

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -31,6 +31,7 @@ class TestSDO(unittest.TestCase):
 
     def setUp(self):
         network = canopen.Network()
+        network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         network.send_message = self._send_message
         node = network.add_node(2, SAMPLE_EDS)
         node.sdo.RESPONSE_TIMEOUT = 0.01
@@ -181,6 +182,7 @@ class TestSDOClientDatatypes(unittest.TestCase):
 
     def setUp(self):
         network = canopen.Network()
+        network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         network.send_message = self._send_message
         node = network.add_node(2, DATATYPES_EDS)
         node.sdo.RESPONSE_TIMEOUT = 0.01

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -12,6 +12,7 @@ TIMEOUT = PERIOD * 10
 class TestSync(unittest.TestCase):
     def setUp(self):
         self.net = canopen.Network()
+        self.net.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         self.net.connect(interface="virtual")
         self.sync = canopen.sync.SyncProducer(self.net)
         self.rxbus = can.Bus(interface="virtual")

--- a/test/test_time.py
+++ b/test/test_time.py
@@ -6,6 +6,7 @@ class TestTime(unittest.TestCase):
 
     def test_time_producer(self):
         network = canopen.Network()
+        network.NOTIFIER_SHUTDOWN_TIMEOUT = 0.0
         network.connect(interface="virtual", receive_own_messages=True)
         producer = canopen.timestamp.TimeProducer(network)
         producer.transmit(1486236238)


### PR DESCRIPTION
Move the hard-coded 1 second maximum cycle duration passed during
`can.Notifier` construction to a class variable `NOTIFIER_CYCLE`.
Explicitly specify the timeout to stop the notifier in another class
variable `NOTIFIER_SHUTDOWN_TIMEOUT`, matching the default used in
python-can.  These can be overridden per instance if needed.

Do not wait for notifier thread shutdown during tests by explicitly setting the `NOTIFIER_SHUTDOWN_TIMEOUT` to zero in all `Network` instances created for unit tests.

This reduces total test running time from ~30 to ~9 seconds when run locally.