### PR TITLE
Tests: Verify some basic SDO record and array assumptions

### DIFF
--- a/test/sample.eds
+++ b/test/sample.eds
@@ -118,10 +118,61 @@ SupportedObjects=3
 [1003]
 ParameterName=Pre-defined error field
 ObjectType=0x8
-CompactSubObj=255
+SubNumber=9
+
+[1003sub0]
+ParameterName=Number of errors
+ObjectType=0x7
+DataType=0x0005
+AccessType=rw
+DefaultValue=3
+PDOMapping=0
+
+[1003sub1]
+ParameterName=Pre-defined error field_1
+ObjectType=0x7
 DataType=0x0007
 AccessType=ro
+DefaultValue=0
 PDOMapping=0
+
+; [1003sub2] left out for testing
+
+[1003sub3]
+ParameterName=Pre-defined error field_3
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+[1003sub4]
+ParameterName=Pre-defined error field_4
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+[1003sub5]
+ParameterName=Pre-defined error field_5
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+; [1003sub6] left out for testing
+
+[1003sub7]
+ParameterName=Pre-defined error field_7
+ObjectType=0x7
+DataType=0x0007
+AccessType=ro
+DefaultValue=0
+PDOMapping=0
+
+; [1003sub8] left out for testing
 
 [1008]
 ParameterName=Manufacturer device name

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -100,12 +100,7 @@ DataType=0x0007
 AccessType=ro
 PDOMapping=0
 
-[1018sub3]
-ParameterName=Revision number
-ObjectType=0x7
-DataType=0x0007
-AccessType=ro
-PDOMapping=0
+; [1018sub3] left out for testing
 
 [1018sub4]
 ParameterName=Serial number

--- a/test/test_eds.py
+++ b/test/test_eds.py
@@ -121,7 +121,7 @@ class TestEDS(unittest.TestCase):
     def test_record(self):
         record = self.od['Identity object']
         self.assertIsInstance(record, canopen.objectdictionary.ODRecord)
-        self.assertEqual(len(record), 5)
+        self.assertEqual(len(record), 4)
         self.assertEqual(record.index, 0x1018)
         self.assertEqual(record.name, 'Identity object')
         var = record['Vendor-ID']

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -23,7 +23,8 @@ class TestSDOVariables(unittest.TestCase):
     def test_record_iter_length(self):
         """Assume the "highest subindex supported" entry is not counted.
 
-        Sub-objects without an OD entry should be skipped as well."""
+        Sub-objects without an OD entry should be skipped as well.
+        """
         record = self.sdo_node[0x1018]
         subs = sum(1 for _ in iter(record))
         self.assertEqual(len(record), 3)

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -20,6 +20,7 @@ class TestSDOVariables(unittest.TestCase):
         node = canopen.LocalNode(1, SAMPLE_EDS)
         self.sdo_node = node.sdo
 
+    @unittest.expectedFailure
     def test_record_iter_length(self):
         """Assume the "highest subindex supported" entry is not counted.
 

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -20,6 +20,17 @@ class TestSDOVariables(unittest.TestCase):
         node = canopen.LocalNode(1, SAMPLE_EDS)
         self.sdo_node = node.sdo
 
+    def test_array_iter_length(self):
+        """Assume the "highest subindex supported" entry is not counted."""
+        array = self.sdo_node[0x1003]
+        subs = sum(1 for _ in iter(array))
+        self.assertEqual(len(array), 3)
+        self.assertEqual(subs, 3)
+        # Simulate more entries getting added dynamically
+        array[0].set_data(b'\x08')
+        subs = sum(1 for _ in iter(array))
+        self.assertEqual(subs, 8)
+
     def test_array_members_dynamic(self):
         """Check if sub-objects missing from OD entry are generated dynamically."""
         array = self.sdo_node[0x1003]

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -20,6 +20,15 @@ class TestSDOVariables(unittest.TestCase):
         node = canopen.LocalNode(1, SAMPLE_EDS)
         self.sdo_node = node.sdo
 
+    def test_record_iter_length(self):
+        """Assume the "highest subindex supported" entry is not counted.
+
+        Sub-objects without an OD entry should be skipped as well."""
+        record = self.sdo_node[0x1018]
+        subs = sum(1 for _ in iter(record))
+        self.assertEqual(len(record), 3)
+        self.assertEqual(subs, 3)
+
     def test_array_iter_length(self):
         """Assume the "highest subindex supported" entry is not counted."""
         array = self.sdo_node[0x1003]

--- a/test/test_sdo.py
+++ b/test/test_sdo.py
@@ -10,6 +10,23 @@ TX = 1
 RX = 2
 
 
+class TestSDOVariables(unittest.TestCase):
+    """Some basic assumptions on the behavior of SDO variable objects.
+
+    Mostly what is stated in the API docs.
+    """
+
+    def setUp(self):
+        node = canopen.LocalNode(1, SAMPLE_EDS)
+        self.sdo_node = node.sdo
+
+    def test_array_members_dynamic(self):
+        """Check if sub-objects missing from OD entry are generated dynamically."""
+        array = self.sdo_node[0x1003]
+        for var in array.values():
+            self.assertIsInstance(var, canopen.sdo.SdoVariable)
+
+
 class TestSDO(unittest.TestCase):
     """
     Test SDO traffic by example. Most are taken from


### PR DESCRIPTION
As requested in #538, this will show where the current `SdoRecord` length / iteration behavior is inconsistent.  Some other tests related to `SdoArray` length and iteration added as well, for symmetry.