### PR TITLE
Support server pdo and added api

### DIFF
--- a/canopen/network.py
+++ b/canopen/network.py
@@ -75,6 +75,9 @@ class Network(MutableMapping):
             If given, remove only this callback.  Otherwise all callbacks for
             the CAN ID.
         """
+        if can_id not in self.subscribers:
+            return
+
         if callback is None:
             del self.subscribers[can_id]
         else:

--- a/canopen/node/local.py
+++ b/canopen/node/local.py
@@ -51,6 +51,7 @@ class LocalNode(BaseNode):
     def remove_network(self) -> None:
         self.network.unsubscribe(self.sdo.rx_cobid, self.sdo.on_request)
         self.network.unsubscribe(0, self.nmt.on_command)
+        self.stop_pdo_services()
         self.network = canopen.network._UNINITIALIZED_NETWORK
         self.sdo.network = canopen.network._UNINITIALIZED_NETWORK
         self.tpdo.network = canopen.network._UNINITIALIZED_NETWORK
@@ -63,6 +64,22 @@ class LocalNode(BaseNode):
 
     def add_write_callback(self, callback):
         self._write_callbacks.append(callback)
+
+    def start_pdo_services(self, period: float):
+        """
+        Start the PDO related services of the node.
+        :param period: Service interval in seconds.
+        """
+        self.rpdo.read(from_od=True)
+        self.tpdo.read(from_od=True, subscribe=False)
+        self.tpdo.start(period=period)
+
+    def stop_pdo_services(self):
+        """
+        Stop the PDO related services of the node.
+        """
+        self.rpdo.unsubscribe()
+        self.tpdo.stop()
 
     def get_data(
         self, index: int, subindex: int, check_readable: bool = False
@@ -118,6 +135,7 @@ class LocalNode(BaseNode):
         # Store data
         self.data_store.setdefault(index, {})
         self.data_store[index][subindex] = bytes(data)
+        self.tpdo.update()
 
     def _find_object(self, index, subindex):
         if index not in self.object_dictionary:

--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -129,10 +129,9 @@ class TPDO(PdoBase):
         """
         if isinstance(self.node, node.LocalNode):
             for pdo in self.map.values():
-                data = pdo.data
                 for variable in pdo:
-                    self.pack_data(data, variable)
-                pdo.start()
+                    self.pack_data(pdo.data, variable)
+                pdo.update()
         else:
             raise TypeError("The node type does not support this function.")
 

--- a/test/sample.eds
+++ b/test/sample.eds
@@ -664,7 +664,7 @@ ObjectType=7
 DataType=7
 AccessType=RW
 PDOMapping=0
-DefaultValue=1614872592
+DefaultValue=0x30100020
 
 [1a00sub2]
 ParameterName=TPDO 1 mapping information 2
@@ -945,7 +945,7 @@ SubNumber=1
 ParameterName=Temperature
 ObjectType=0x7
 DataType=0x0008
-AccessType=ro
+AccessType=rw
 DefaultValue=0
 PDOMapping=1
 

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -144,6 +144,8 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(accumulators[2], [(2, bytes([4, 5, 6]), 1003)])
 
         self.network.unsubscribe(0)
+        # Should not raise an error.
+        self.network.unsubscribe(10)
         self.network.notify(0, bytes([7, 7, 7]), 1004)
         # Verify that no new data was added to the accumulator.
         self.assertEqual(accumulators[0], [(0, bytes([1, 2, 3]), 1000)])

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -80,6 +80,16 @@ class TestPDO(unittest.TestCase):
                         self.assertIn("ID", header)
                         self.assertIn("Frame Name", header)
 
+    def test_tpdo_start_stop(self):
+        network = canopen.Network()
+        network.connect("test", interface="virtual")
+        self.node.associate_network(network)
+        self.node.tpdo[1].start(period=0.01)
+        self.node.tpdo[1].stop()
+
+    def test_rpdo_subscribe_unsubscribe(self):
+        self.node.rpdo.subscribe()
+        self.node.rpdo.unsubscribe()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I was trying to utilize this repo to support canopen server functionality and ran into a few items that would've been helpful to aid in the usability and expanded functionality. Some key changes were the addition of being able to start pdo services from the local_node layer this made it easier to use in other repos. I expanded the functionality of the pdo classes mainly to be used by the tpdo but can be expanded to do more in the future if needed. By calling the start_pdo_services the tpdo can read and load in the desired mapping needed and start transmitting data. When the data is updated in the node the tpdo data can be updated as well. I added a packing data method to pack the new data into the existing tpdo data and then update the message. 