### PR TITLE
Fix SDO writes of empty strings

### DIFF
--- a/canopen/sdo/client.py
+++ b/canopen/sdo/client.py
@@ -353,7 +353,7 @@ class WritableStream(io.RawIOBase):
         self._exp_header = None
         self._done = False
 
-        if size is None or size > 4 or force_segment:
+        if size is None or size < 1 or size > 4 or force_segment:
             # Initiate segmented download
             request = bytearray(8)
             command = REQUEST_DOWNLOAD


### PR DESCRIPTION
Previously, when attempting a write of `""` to a `VISIBLE_STRING`, the expedited SDO request would not be sent and the transaction would timeout.

I traced this down to the `BufferedWriter` not issuing a write to the underlying stream when it has only been called with `b""`. Additionally, it turns out that it's not possible to correctly send an expedited SDO request with size == 0. 

To resolve this, if the transaction size is known to be `0`, a segmented transfer is used.