### PR TITLE
Fix and extend PDO selection by record IDs (fixes #607)

### DIFF
--- a/canopen/pdo/__init__.py
+++ b/canopen/pdo/__init__.py
@@ -1,4 +1,6 @@
+import itertools
 import logging
+from collections.abc import Iterator
 
 from canopen import node
 from canopen.pdo.base import PdoBase, PdoMap, PdoMaps, PdoVariable
@@ -24,23 +26,36 @@ class PDO(PdoBase):
     :param tpdo: TPDO object holding the Transmit PDO mappings
     """
 
-    def __init__(self, node, rpdo, tpdo):
+    def __init__(self, node, rpdo: PdoBase, tpdo: PdoBase):
         super(PDO, self).__init__(node)
         self.rx = rpdo.map
         self.tx = tpdo.map
 
-        self.map = {}
-        # the object 0x1A00 equals to key '1' so we remove 1 from the key
+        self.map = PdoMaps(0, 0, self)
+        # Combine RX and TX entries, but only via mapping parameter index.  Relative index
+        # numbers would be ambiguous.
+        # The object 0x1A00 equals to key '1' so we remove 1 from the key
         for key, value in self.rx.items():
-            self.map[0x1A00 + (key - 1)] = value
+            self.map.maps[self.rx.map_offset + (key - 1)] = value
+            self.map.maps[self.rx.com_offset + (key - 1)] = value
         for key, value in self.tx.items():
-            self.map[0x1600 + (key - 1)] = value
+            self.map.maps[self.tx.map_offset + (key - 1)] = value
+            self.map.maps[self.tx.com_offset + (key - 1)] = value
+
+    def __iter__(self) -> Iterator[int]:
+        return itertools.chain(
+            (self.rx.map_offset + i - 1 for i in self.rx),
+            (self.tx.map_offset + i - 1 for i in self.tx),
+        )
+
+    def __len__(self) -> int:
+        return len(self.rx) + len(self.tx)
 
 
 class RPDO(PdoBase):
     """Receive PDO to transfer data from somewhere to the represented node.
 
-    Properties 0x1400 to 0x1403 | Mapping 0x1600 to 0x1603.
+    Properties 0x1400 to 0x15FF | Mapping 0x1600 to 0x17FF.
     :param object node: Parent node for this object.
     """
 
@@ -65,7 +80,7 @@ class RPDO(PdoBase):
 class TPDO(PdoBase):
     """Transmit PDO to broadcast data from the represented node to the network.
 
-    Properties 0x1800 to 0x1803 | Mapping 0x1A00 to 0x1A03.
+    Properties 0x1800 to 0x19FF | Mapping 0x1A00 to 0x1BFF.
     :param object node: Parent node for this object.
     """
 


### PR DESCRIPTION
This PR corrects mixed up mapping parameter record index numbers, adds support for lookup by record IDs, and updates tests. Based on commit 593f0621f41ce3f94c09322ca8414c7e649b128e.