### PR TITLE
pdo: Fix wrongfully returned object for missing index

### DIFF
--- a/canopen/pdo/base.py
+++ b/canopen/pdo/base.py
@@ -175,10 +175,12 @@ class PdoMaps(Mapping[int, 'PdoMap']):
         try:
             return self.maps[key]
         except KeyError:
-            with contextlib.suppress(KeyError):
-                return self.maps[key + 1 - self.map_offset]
-            with contextlib.suppress(KeyError):
-                return self.maps[key + 1 - self.com_offset]
+            if self.map_offset:
+                with contextlib.suppress(KeyError):
+                    return self.maps[key + 1 - self.map_offset]
+            if self.com_offset:
+                with contextlib.suppress(KeyError):
+                    return self.maps[key + 1 - self.com_offset]
             raise
 
     def __iter__(self) -> Iterator[int]:

--- a/test/test_pdo.py
+++ b/test/test_pdo.py
@@ -80,6 +80,7 @@ class TestPDO(unittest.TestCase):
         self.assertRaises(KeyError, lambda: node.pdo['DOES NOT EXIST'])
         self.assertRaises(KeyError, lambda: node.pdo[0x1BFF])
         self.assertRaises(KeyError, lambda: node.tpdo[0x1BFF])
+        self.assertRaises(KeyError, lambda: node.pdo[0x15FF])
 
     def test_pdo_iterate(self):
         node = self.node


### PR DESCRIPTION
The fallback behavior in `PdoMaps.__getitem__()` tried looking up by parameter record index even when no `com_offset` or `map_offset` was defined.  This caused a possibly wrong `PdoMap` object to be returned.  For example with 0x15FF, the lookup for 0x1600 would succeed.

Add a test to make sure that an nonexistant parameter record index for 0x15FF actually does raise a `KeyError`.  Skip the fallback lookup by parameter index if no record offsets are defined.